### PR TITLE
Update example IETC call

### DIFF
--- a/examples/basic_usage.py
+++ b/examples/basic_usage.py
@@ -57,14 +57,11 @@ print(f"Income Tax for an income of ${income}: ${tax_16_17:.2f}")
 
 # Calculate IETC
 ietc_16_17 = calcietc(
-    taxy=income,
-    parmflag="ys",
-    wffamt=0,
-    supamt=0,
-    benamt=0,
+    taxable_income=income,
+    is_wff_recipient=False,
+    is_super_recipient=False,
+    is_benefit_recipient=False,
     ietc_params=params_2016_17["ietc"],
-    ietc0=1,
-    taxinc0=income,
 )
 print(f"IETC: ${ietc_16_17:.2f}")
 
@@ -92,14 +89,11 @@ print(f"Income Tax for an income of ${income}: ${tax_24_25:.2f}")
 
 # Calculate IETC
 ietc_24_25 = calcietc(
-    taxy=income,
-    parmflag="ys",
-    wffamt=0,
-    supamt=0,
-    benamt=0,
+    taxable_income=income,
+    is_wff_recipient=False,
+    is_super_recipient=False,
+    is_benefit_recipient=False,
     ietc_params=params_2024_25["ietc"],
-    ietc0=1,
-    taxinc0=income,
 )
 print(f"IETC: ${ietc_24_25:.2f}")
 


### PR DESCRIPTION
## Summary
- update `examples/basic_usage.py` to use the new `calcietc` argument names

## Testing
- `ruff check .`
- `pytest -q` *(fails: cannot import name `calculate_child_poverty_rate`)*

------
https://chatgpt.com/codex/tasks/task_e_6886f2b1865483319d5f508569aefee8