### PR TITLE
Add runtime packages to pyproject and dev setup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,8 @@ install:
 	pip install .
 
 install-dev-deps:
-	pip install -r requirements-dev.txt
+        pip install -e .
+        pip install -r requirements-dev.txt
 
 test:
 	pytest

--- a/README.md
+++ b/README.md
@@ -132,7 +132,8 @@ This project uses a `Makefile` to automate common development tasks. You can fin
 
 ### Installing Development Dependencies
 
-To install all development dependencies (including `pytest`, `ruff`, and `pre-commit`), run:
+To install all development dependencies (including `pytest`, `ruff`, and `pre-commit`) along with the project itself,
+run:
 
 ```bash
 make install-dev-deps

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,9 @@ dependencies = [
     "pandas",
     "numpy",
     "pydantic",
+    "matplotlib",
+    "seaborn",
+    "joblib",
 ]
 
 [tool.pytest.ini_options]

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,3 +1,6 @@
 pytest
 ruff
 pre-commit
+matplotlib
+seaborn
+joblib


### PR DESCRIPTION
## Summary
- install main dependencies when using `make install-dev-deps`
- document updated dev install instructions
- list matplotlib, seaborn, and joblib as project dependencies
- include runtime packages in requirements-dev.txt

## Testing
- `ruff check .`
- `ruff format --check .`
- `pytest -q` *(fails: cannot import name 'calculate_child_poverty_rate')*

------
https://chatgpt.com/codex/tasks/task_e_6886f2c865d48331a2f9ac13efe9ffb3