### PR TITLE
Add tabulate to dev requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,12 +147,14 @@ This project uses a `Makefile` to automate common development tasks. You can fin
 
 ### Installing Development Dependencies
 
-To install all development dependencies (including `pytest`, `ruff`, and `pre-commit`) along with the project itself,
+To install all development dependencies (including `pytest`, `ruff`, `pre-commit`, and `tabulate`) along with the project itself,
 run:
 
 ```bash
 make install-dev-deps
 ```
+
+`tabulate` is required so that `DataFrame.to_markdown()` works correctly during tests.
 
 ### Running Tests
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,3 +4,4 @@ pre-commit
 matplotlib
 seaborn
 joblib
+tabulate


### PR DESCRIPTION
## Summary
- add `tabulate` package to dev requirements
- mention `tabulate` in README dev dependency instructions

## Testing
- `pip install -e .`
- `pip install -r requirements-dev.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6887105687b08331ae7f69d5cc94b99d

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated installation instructions to include the tabulate package as a required development dependency and clarified its use in testing.

* **Chores**
  * Added the tabulate package to the list of development requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->