### PR TITLE
Add EVPI calculation helper

### DIFF
--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,0 +1,5 @@
+"""Utility imports for the NZ microsimulation package."""
+
+from .value_of_information import calculate_evpi
+
+__all__ = ["calculate_evpi"]

--- a/src/value_of_information.py
+++ b/src/value_of_information.py
@@ -1,0 +1,49 @@
+import numpy as np
+from typing import Dict
+
+
+def calculate_evpi(psa_results: Dict[str, np.ndarray]) -> Dict[str, float]:
+    """Calculate the Expected Value of Perfect Information (EVPI).
+
+    Parameters
+    ----------
+    psa_results : Dict[str, np.ndarray]
+        Dictionary mapping output metric names to two-dimensional arrays of
+        probabilistic sensitivity analysis results. Each array must have shape
+        ``(n_options, n_simulations)`` where ``n_options`` is the number of
+        decision options being compared and ``n_simulations`` is the number of
+        PSA iterations.
+
+    Returns
+    -------
+    Dict[str, float]
+        A dictionary mapping each metric name to its EVPI value.
+
+    Notes
+    -----
+    EVPI represents the expected gain in the chosen outcome metric if the true
+    state of the world (i.e., the uncertain parameters) were known with
+    certainty before making a decision. For each metric, EVPI is computed as::
+
+        EVPI = E[max_j x_{ij}] - max_i E[x_{ij}]
+
+    where ``x_{ij}`` is the simulated outcome for option ``i`` in simulation
+    ``j``.
+    """
+
+    evpi_values: Dict[str, float] = {}
+    for metric, data in psa_results.items():
+        if data.ndim != 2:
+            raise ValueError(
+                f"Values in psa_results must be 2D arrays of shape (n_options, n_simulations); got {data.ndim}D array"
+            )
+
+        # Expected value with perfect information: pick the best option for each simulation
+        mean_perfect = float(np.mean(np.max(data, axis=0)))
+
+        # Expected value with current information: pick the option with the highest mean outcome
+        mean_current = float(np.max(np.mean(data, axis=1)))
+
+        evpi_values[metric] = mean_perfect - mean_current
+
+    return evpi_values

--- a/tests/test_value_of_information.py
+++ b/tests/test_value_of_information.py
@@ -1,0 +1,22 @@
+"""Unit tests for the value_of_information module."""
+
+import numpy as np
+import pytest
+
+from src.value_of_information import calculate_evpi
+
+
+def test_calculate_evpi():
+    """EVPI should match manual calculation for a simple example."""
+    data = np.array([[100, 150, 130], [120, 140, 125]])
+    psa = {"Net Cost": data}
+    result = calculate_evpi(psa)
+    expected = np.mean(np.max(data, axis=0)) - np.max(np.mean(data, axis=1))
+    assert result["Net Cost"] == pytest.approx(expected)
+
+
+def test_calculate_evpi_invalid_shape():
+    """Providing a 1D array should raise a ValueError."""
+    psa = {"Metric": np.array([1, 2, 3])}
+    with pytest.raises(ValueError):
+        calculate_evpi(psa)


### PR DESCRIPTION
## Summary
- implement `calculate_evpi` to compute expected value of perfect information
- expose the helper in `src.__init__`
- add unit tests for the EVPI calculation

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688733f9069c83318ce90a14b5eb9f39

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a function to compute the Expected Value of Perfect Information (EVPI) from probabilistic sensitivity analysis results.

* **Tests**
  * Introduced unit tests to verify the correctness of the EVPI calculation and to ensure proper error handling for invalid input shapes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->