### PR TITLE
Add inequality metrics

### DIFF
--- a/src/reporting.py
+++ b/src/reporting.py
@@ -11,6 +11,9 @@ from src.reporting_framework import (
     IncomeDecileImpactChart,
     PovertyRateChangesChart,
     ReportGenerator,
+    calculate_atkinson_index,
+    calculate_lorenz_curve,
+    calculate_theil_index,
 )
 
 # Instantiate helpers used by the backward compatible wrapper functions.
@@ -61,6 +64,21 @@ def calculate_child_poverty_rate(df: pd.DataFrame, income_column: str, poverty_l
 def calculate_gini_coefficient(income_series: pd.Series) -> float:
     """Return the Gini coefficient for ``income_series``."""
     return _stats_helper._calculate_gini_coefficient(income_series)
+
+
+def lorenz_curve(income_series: pd.Series) -> pd.DataFrame:
+    """Return the Lorenz curve for ``income_series``."""
+    return calculate_lorenz_curve(income_series)
+
+
+def atkinson_index(income_series: pd.Series, epsilon: float = 0.5) -> float:
+    """Return the Atkinson inequality index for ``income_series``."""
+    return calculate_atkinson_index(income_series, epsilon)
+
+
+def theil_index(income_series: pd.Series) -> float:
+    """Return the Theil T index for ``income_series``."""
+    return calculate_theil_index(income_series)
 
 
 def generate_microsim_report(simulated_data: pd.DataFrame, report_params: Dict[str, Any]) -> Dict[str, Any]:
@@ -122,5 +140,8 @@ __all__ = [
     "calculate_poverty_rate",
     "calculate_child_poverty_rate",
     "calculate_gini_coefficient",
+    "lorenz_curve",
+    "atkinson_index",
+    "theil_index",
     "generate_microsim_report",
 ]

--- a/src/reporting_framework.py
+++ b/src/reporting_framework.py
@@ -7,6 +7,49 @@ import pandas as pd
 import seaborn as sns
 
 
+def calculate_lorenz_curve(income_series: pd.Series) -> pd.DataFrame:
+    """Return cumulative income shares for the Lorenz curve."""
+    if income_series.empty:
+        return pd.DataFrame({"population_share": [0.0], "income_share": [0.0]})
+
+    sorted_income = income_series.sort_values().to_numpy()
+    cum_income = np.cumsum(sorted_income)
+    total_income = cum_income[-1]
+    population_share = np.arange(1, len(sorted_income) + 1) / len(sorted_income)
+    income_share = cum_income / total_income if total_income != 0 else cum_income
+
+    # Prepend origin (0,0)
+    population_share = np.insert(population_share, 0, 0.0)
+    income_share = np.insert(income_share, 0, 0.0)
+    return pd.DataFrame({"population_share": population_share, "income_share": income_share})
+
+
+def calculate_atkinson_index(income_series: pd.Series, epsilon: float = 0.5) -> float:
+    """Return the Atkinson index for ``income_series``."""
+    values = income_series[income_series > 0].to_numpy()
+    if values.size == 0:
+        return 0.0
+
+    mean_income = values.mean()
+    if epsilon == 1:
+        geo_mean = np.exp(np.log(values).mean())
+        return 1 - geo_mean / mean_income
+    else:
+        exp_val = (values ** (1 - epsilon)).mean() ** (1 / (1 - epsilon))
+        return 1 - exp_val / mean_income
+
+
+def calculate_theil_index(income_series: pd.Series) -> float:
+    """Return the Theil T index for ``income_series``."""
+    values = income_series[income_series > 0].to_numpy()
+    if values.size == 0:
+        return 0.0
+
+    mean_income = values.mean()
+    ratios = values / mean_income
+    return float(np.mean(ratios * np.log(ratios)))
+
+
 # Define a base class for report components to ensure modularity and a common interface
 class ReportComponent:
     """

--- a/tests/test_reporting.py
+++ b/tests/test_reporting.py
@@ -1,6 +1,7 @@
 import pandas as pd
 import pytest
 
+import src.reporting as reporting
 from src.reporting import (
     calculate_child_poverty_rate,
     calculate_disposable_income,
@@ -172,3 +173,21 @@ def test_generate_microsim_report_expected_keys(sample_dataframe, tmp_path, monk
 
     assert "Executive Summary" in result
     assert "Fiscal Impact Summary" in result
+
+
+def test_lorenz_and_inequality_indices():
+    incomes = pd.Series([1, 2, 3, 4])
+
+    # Lorenz curve should start at (0,0) and end at (1,1)
+    lorenz = reporting.lorenz_curve(incomes)
+    expected = pd.DataFrame(
+        {
+            "population_share": [0.0, 0.25, 0.5, 0.75, 1.0],
+            "income_share": [0.0, 0.1, 0.3, 0.6, 1.0],
+        }
+    )
+    pd.testing.assert_frame_equal(lorenz.reset_index(drop=True), expected)
+
+    # Atkinson and Theil indices for this distribution
+    assert reporting.atkinson_index(incomes, epsilon=0.5) == pytest.approx(0.0556, abs=1e-3)
+    assert reporting.theil_index(incomes) == pytest.approx(0.1064, abs=1e-3)


### PR DESCRIPTION
## Summary
- implement Lorenz curve, Atkinson and Theil index helpers
- expose these new utilities via `reporting` API
- test inequality functions

## Testing
- `ruff check .`
- `ruff format src tests`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688733f8a0e48331b2d8669210eb83a2