### PR TITLE
Add sensitivity analysis tests

### DIFF
--- a/src/sensitivity_analysis.py
+++ b/src/sensitivity_analysis.py
@@ -213,4 +213,8 @@ def run_probabilistic_analysis(
         for name, value in res.items():
             output_arrays[name].append(value)
 
+
     return {name: np.array(data) for name, data in output_arrays.items()}
+
+
+__all__ = ["run_deterministic_analysis", "run_probabilistic_analysis"]

--- a/tests/test_sensitivity.py
+++ b/tests/test_sensitivity.py
@@ -1,0 +1,83 @@
+import numpy as np
+import pandas as pd
+
+from src.sensitivity_analysis import run_deterministic_analysis, run_probabilistic_analysis
+
+
+def dummy_tax(income: float, rates: list[float], thresholds: list[float]) -> float:
+    if income <= thresholds[0]:
+        return income * rates[0]
+    return thresholds[0] * rates[0] + (income - thresholds[0]) * rates[1]
+
+
+def dummy_wff(df: pd.DataFrame, wff_params: dict[str, float], wagegwt: float, days: int) -> pd.DataFrame:
+    df = df.copy()
+    df["ent"] = wff_params["ftc1"] * df["weight"]
+    return df
+
+
+population = pd.DataFrame({"familyinc": [4000, 6000], "weight": [1, 2]})
+
+baseline_params = {
+    "wff": {"ftc1": 100},
+    "tax_brackets": {"rates": [0.1, 0.2], "thresholds": [5000]},
+}
+
+
+def total_wff(df: pd.DataFrame) -> float:
+    return df["ent"].sum()
+
+
+def total_tax(df: pd.DataFrame) -> float:
+    return df["tax"].sum()
+
+
+def net_cost(tax_df: pd.DataFrame, wff_df: pd.DataFrame) -> float:
+    return total_wff(wff_df) - total_tax(tax_df)
+
+
+metrics = {
+    "Total WFF Entitlement": total_wff,
+    "Total Tax Revenue": total_tax,
+    "Net Cost to Government": net_cost,
+}
+
+
+def test_run_deterministic_analysis_shape_and_impact():
+    params_to_vary = ["wff.ftc1", "tax_brackets.rates.0"]
+    results = run_deterministic_analysis(
+        baseline_params.copy(),
+        params_to_vary,
+        0.1,
+        population,
+        metrics,
+        dummy_wff,
+        dummy_tax,
+    )
+
+    assert set(results) == set(metrics)
+    for df in results.values():
+        assert df.shape[0] == len(params_to_vary)
+        assert set(df.columns) == {"parameter", "low_value", "high_value", "baseline", "impact"}
+        np.testing.assert_allclose(df["impact"], df["high_value"] - df["low_value"])
+
+
+def test_run_probabilistic_analysis_shape():
+    param_dists = {
+        "wff.ftc1": {"dist": "norm", "loc": 100, "scale": 1},
+        "tax_brackets.rates.0": {"dist": "uniform", "loc": 0.1, "scale": 0.01},
+    }
+    num_samples = 5
+    results = run_probabilistic_analysis(
+        param_dists,
+        num_samples,
+        population,
+        metrics,
+        dummy_wff,
+        dummy_tax,
+    )
+
+    assert set(results) == set(metrics)
+    for arr in results.values():
+        assert isinstance(arr, np.ndarray)
+        assert arr.shape == (num_samples,)


### PR DESCRIPTION
## Summary
- test deterministic and probabilistic sensitivity analysis with small dataframes
- export functions from sensitivity_analysis

## Testing
- `ruff check tests/test_sensitivity.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688733f7ca488331806953b9c914ab84