### PR TITLE
Add PPL and child support parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `CONTRIBUTING.md` with contribution guidelines.
 - `CITATION.cff` for citation information.
 - Optional modules for Paid Parental Leave and child support modelling.
+- All yearly parameter files now include `ppl` and `child_support` sections so
+  these modules can be enabled for any simulation year.
 - `SECURITY.md` for vulnerability reporting.
 - `sas_models/` directory for original SAS model files.
 - `docs/` directory for documentation files.

--- a/README.md
+++ b/README.md
@@ -135,7 +135,9 @@ The model includes simple components for Paid Parental Leave (PPL) and child
 support. These modules are off by default. To activate them, set
 `ppl.enabled` or `child_support.enabled` to `true` in the parameter JSON file.
 PPL requires `weekly_rate` and `max_weeks` values, while child support uses a
-`support_rate` applied to the liable parent's income.
+`support_rate` applied to the liable parent's income. The parameters are
+available in every yearly JSON file so the modules can be toggled for any
+simulation year.
 
 ### Policy Comparison
 

--- a/src/parameters_2005-2006.json
+++ b/src/parameters_2005-2006.json
@@ -1,7 +1,14 @@
 {
   "tax_brackets": {
-    "rates": [0.195, 0.33, 0.39],
-    "thresholds": [38000, 60000]
+    "rates": [
+      0.195,
+      0.33,
+      0.39
+    ],
+    "thresholds": [
+      38000,
+      60000
+    ]
   },
   "ietc": {
     "thrin": 520,
@@ -22,5 +29,14 @@
     "abaterate2": 0.3,
     "bstcthresh": 0,
     "bstcabate": 0
+  },
+  "ppl": {
+    "enabled": false,
+    "weekly_rate": 712.17,
+    "max_weeks": 26
+  },
+  "child_support": {
+    "enabled": false,
+    "support_rate": 0.18
   }
 }

--- a/src/parameters_2006-2007.json
+++ b/src/parameters_2006-2007.json
@@ -1,7 +1,16 @@
 {
   "tax_brackets": {
-    "rates": [0.15, 0.29, 0.39, 0.45],
-    "thresholds": [9500, 34000, 60000]
+    "rates": [
+      0.15,
+      0.29,
+      0.39,
+      0.45
+    ],
+    "thresholds": [
+      9500,
+      34000,
+      60000
+    ]
   },
   "ietc": {
     "thrin": 520,
@@ -22,5 +31,14 @@
     "abaterate2": 0.3,
     "bstcthresh": 0,
     "bstcabate": 0
+  },
+  "ppl": {
+    "enabled": false,
+    "weekly_rate": 712.17,
+    "max_weeks": 26
+  },
+  "child_support": {
+    "enabled": false,
+    "support_rate": 0.18
   }
 }

--- a/src/parameters_2007-2008.json
+++ b/src/parameters_2007-2008.json
@@ -1,7 +1,16 @@
 {
   "tax_brackets": {
-    "rates": [0.15, 0.29, 0.39, 0.45],
-    "thresholds": [9500, 34000, 60000]
+    "rates": [
+      0.15,
+      0.29,
+      0.39,
+      0.45
+    ],
+    "thresholds": [
+      9500,
+      34000,
+      60000
+    ]
   },
   "ietc": {
     "thrin": 520,
@@ -22,5 +31,14 @@
     "abaterate2": 0.2,
     "bstcthresh": 0,
     "bstcabate": 0
+  },
+  "ppl": {
+    "enabled": false,
+    "weekly_rate": 712.17,
+    "max_weeks": 26
+  },
+  "child_support": {
+    "enabled": false,
+    "support_rate": 0.18
   }
 }

--- a/src/parameters_2008-2009.json
+++ b/src/parameters_2008-2009.json
@@ -1,7 +1,16 @@
 {
   "tax_brackets": {
-    "rates": [0.15, 0.29, 0.39, 0.45],
-    "thresholds": [9500, 34000, 60000]
+    "rates": [
+      0.15,
+      0.29,
+      0.39,
+      0.45
+    ],
+    "thresholds": [
+      9500,
+      34000,
+      60000
+    ]
   },
   "ietc": {
     "thrin": 520,
@@ -22,5 +31,14 @@
     "abaterate2": 0.2,
     "bstcthresh": 0,
     "bstcabate": 0
+  },
+  "ppl": {
+    "enabled": false,
+    "weekly_rate": 712.17,
+    "max_weeks": 26
+  },
+  "child_support": {
+    "enabled": false,
+    "support_rate": 0.18
   }
 }

--- a/src/parameters_2009-2010.json
+++ b/src/parameters_2009-2010.json
@@ -1,7 +1,16 @@
 {
   "tax_brackets": {
-    "rates": [0.125, 0.21, 0.33, 0.38],
-    "thresholds": [14000, 40000, 70000]
+    "rates": [
+      0.125,
+      0.21,
+      0.33,
+      0.38
+    ],
+    "thresholds": [
+      14000,
+      40000,
+      70000
+    ]
   },
   "ietc": {
     "thrin": 520,
@@ -22,5 +31,14 @@
     "abaterate2": 0.2,
     "bstcthresh": 0,
     "bstcabate": 0
+  },
+  "ppl": {
+    "enabled": false,
+    "weekly_rate": 712.17,
+    "max_weeks": 26
+  },
+  "child_support": {
+    "enabled": false,
+    "support_rate": 0.18
   }
 }

--- a/src/parameters_2010-2011.json
+++ b/src/parameters_2010-2011.json
@@ -1,7 +1,16 @@
 {
   "tax_brackets": {
-    "rates": [0.125, 0.22, 0.33, 0.38],
-    "thresholds": [14000, 48000, 70000]
+    "rates": [
+      0.125,
+      0.22,
+      0.33,
+      0.38
+    ],
+    "thresholds": [
+      14000,
+      48000,
+      70000
+    ]
   },
   "ietc": {
     "thrin": 24000,
@@ -22,5 +31,14 @@
     "abaterate2": 0.2,
     "bstcthresh": 0,
     "bstcabate": 0
+  },
+  "ppl": {
+    "enabled": false,
+    "weekly_rate": 712.17,
+    "max_weeks": 26
+  },
+  "child_support": {
+    "enabled": false,
+    "support_rate": 0.18
   }
 }

--- a/src/parameters_2011-2012.json
+++ b/src/parameters_2011-2012.json
@@ -1,7 +1,16 @@
 {
   "tax_brackets": {
-    "rates": [0.105, 0.175, 0.30, 0.33],
-    "thresholds": [14000, 48000, 70000]
+    "rates": [
+      0.105,
+      0.175,
+      0.30,
+      0.33
+    ],
+    "thresholds": [
+      14000,
+      48000,
+      70000
+    ]
   },
   "ietc": {
     "thrin": 24000,
@@ -22,5 +31,14 @@
     "abaterate2": 0.225,
     "bstcthresh": 0,
     "bstcabate": 0
+  },
+  "ppl": {
+    "enabled": false,
+    "weekly_rate": 712.17,
+    "max_weeks": 26
+  },
+  "child_support": {
+    "enabled": false,
+    "support_rate": 0.18
   }
 }

--- a/src/parameters_2012-2013.json
+++ b/src/parameters_2012-2013.json
@@ -1,7 +1,16 @@
 {
   "tax_brackets": {
-    "rates": [0.105, 0.175, 0.30, 0.33],
-    "thresholds": [14000, 48000, 70000]
+    "rates": [
+      0.105,
+      0.175,
+      0.30,
+      0.33
+    ],
+    "thresholds": [
+      14000,
+      48000,
+      70000
+    ]
   },
   "ietc": {
     "thrin": 24000,
@@ -22,5 +31,14 @@
     "abaterate2": 0.225,
     "bstcthresh": 0,
     "bstcabate": 0
+  },
+  "ppl": {
+    "enabled": false,
+    "weekly_rate": 712.17,
+    "max_weeks": 26
+  },
+  "child_support": {
+    "enabled": false,
+    "support_rate": 0.18
   }
 }

--- a/src/parameters_2013-2014.json
+++ b/src/parameters_2013-2014.json
@@ -1,7 +1,16 @@
 {
   "tax_brackets": {
-    "rates": [0.105, 0.175, 0.30, 0.33],
-    "thresholds": [14000, 48000, 70000]
+    "rates": [
+      0.105,
+      0.175,
+      0.30,
+      0.33
+    ],
+    "thresholds": [
+      14000,
+      48000,
+      70000
+    ]
   },
   "ietc": {
     "thrin": 24000,
@@ -22,5 +31,14 @@
     "abaterate2": 0.225,
     "bstcthresh": 0,
     "bstcabate": 0
+  },
+  "ppl": {
+    "enabled": false,
+    "weekly_rate": 712.17,
+    "max_weeks": 26
+  },
+  "child_support": {
+    "enabled": false,
+    "support_rate": 0.18
   }
 }

--- a/src/parameters_2014-2015.json
+++ b/src/parameters_2014-2015.json
@@ -1,7 +1,16 @@
 {
   "tax_brackets": {
-    "rates": [0.105, 0.175, 0.30, 0.33],
-    "thresholds": [14000, 48000, 70000]
+    "rates": [
+      0.105,
+      0.175,
+      0.30,
+      0.33
+    ],
+    "thresholds": [
+      14000,
+      48000,
+      70000
+    ]
   },
   "ietc": {
     "thrin": 24000,
@@ -22,5 +31,14 @@
     "abaterate2": 0.225,
     "bstcthresh": 0,
     "bstcabate": 0
+  },
+  "ppl": {
+    "enabled": false,
+    "weekly_rate": 712.17,
+    "max_weeks": 26
+  },
+  "child_support": {
+    "enabled": false,
+    "support_rate": 0.18
   }
 }

--- a/src/parameters_2015-2016.json
+++ b/src/parameters_2015-2016.json
@@ -1,7 +1,16 @@
 {
   "tax_brackets": {
-    "rates": [0.105, 0.175, 0.30, 0.33],
-    "thresholds": [14000, 48000, 70000]
+    "rates": [
+      0.105,
+      0.175,
+      0.30,
+      0.33
+    ],
+    "thresholds": [
+      14000,
+      48000,
+      70000
+    ]
   },
   "ietc": {
     "thrin": 24000,
@@ -22,5 +31,14 @@
     "abaterate2": 0.225,
     "bstcthresh": 0,
     "bstcabate": 0
+  },
+  "ppl": {
+    "enabled": false,
+    "weekly_rate": 712.17,
+    "max_weeks": 26
+  },
+  "child_support": {
+    "enabled": false,
+    "support_rate": 0.18
   }
 }

--- a/src/parameters_2016-2017.json
+++ b/src/parameters_2016-2017.json
@@ -1,7 +1,16 @@
 {
   "tax_brackets": {
-    "rates": [0.105, 0.175, 0.30, 0.33],
-    "thresholds": [14000, 48000, 70000]
+    "rates": [
+      0.105,
+      0.175,
+      0.30,
+      0.33
+    ],
+    "thresholds": [
+      14000,
+      48000,
+      70000
+    ]
   },
   "ietc": {
     "thrin": 24000,
@@ -22,5 +31,14 @@
     "abaterate2": 0.225,
     "bstcthresh": 0,
     "bstcabate": 0
+  },
+  "ppl": {
+    "enabled": false,
+    "weekly_rate": 712.17,
+    "max_weeks": 26
+  },
+  "child_support": {
+    "enabled": false,
+    "support_rate": 0.18
   }
 }

--- a/src/parameters_2017-2018.json
+++ b/src/parameters_2017-2018.json
@@ -1,7 +1,16 @@
 {
   "tax_brackets": {
-    "rates": [0.105, 0.175, 0.30, 0.33],
-    "thresholds": [14000, 48000, 70000]
+    "rates": [
+      0.105,
+      0.175,
+      0.30,
+      0.33
+    ],
+    "thresholds": [
+      14000,
+      48000,
+      70000
+    ]
   },
   "ietc": {
     "thrin": 24000,
@@ -22,5 +31,14 @@
     "abaterate2": 0.225,
     "bstcthresh": 0,
     "bstcabate": 0
+  },
+  "ppl": {
+    "enabled": false,
+    "weekly_rate": 712.17,
+    "max_weeks": 26
+  },
+  "child_support": {
+    "enabled": false,
+    "support_rate": 0.18
   }
 }

--- a/src/parameters_2018-2019.json
+++ b/src/parameters_2018-2019.json
@@ -1,7 +1,16 @@
 {
   "tax_brackets": {
-    "rates": [0.105, 0.175, 0.30, 0.33],
-    "thresholds": [14000, 48000, 70000]
+    "rates": [
+      0.105,
+      0.175,
+      0.30,
+      0.33
+    ],
+    "thresholds": [
+      14000,
+      48000,
+      70000
+    ]
   },
   "ietc": {
     "thrin": 24000,
@@ -22,5 +31,14 @@
     "abaterate2": 0.2438,
     "bstcthresh": 0,
     "bstcabate": 0
+  },
+  "ppl": {
+    "enabled": false,
+    "weekly_rate": 712.17,
+    "max_weeks": 26
+  },
+  "child_support": {
+    "enabled": false,
+    "support_rate": 0.18
   }
 }

--- a/src/parameters_2019-2020.json
+++ b/src/parameters_2019-2020.json
@@ -1,7 +1,16 @@
 {
   "tax_brackets": {
-    "rates": [0.105, 0.175, 0.30, 0.33],
-    "thresholds": [14000, 48000, 70000]
+    "rates": [
+      0.105,
+      0.175,
+      0.30,
+      0.33
+    ],
+    "thresholds": [
+      14000,
+      48000,
+      70000
+    ]
   },
   "ietc": {
     "thrin": 24000,
@@ -22,5 +31,14 @@
     "abaterate2": 0.25,
     "bstcthresh": 0,
     "bstcabate": 0
+  },
+  "ppl": {
+    "enabled": false,
+    "weekly_rate": 712.17,
+    "max_weeks": 26
+  },
+  "child_support": {
+    "enabled": false,
+    "support_rate": 0.18
   }
 }

--- a/src/parameters_2020-2021.json
+++ b/src/parameters_2020-2021.json
@@ -1,7 +1,16 @@
 {
   "tax_brackets": {
-    "rates": [0.105, 0.175, 0.30, 0.33],
-    "thresholds": [14000, 48000, 70000]
+    "rates": [
+      0.105,
+      0.175,
+      0.30,
+      0.33
+    ],
+    "thresholds": [
+      14000,
+      48000,
+      70000
+    ]
   },
   "ietc": {
     "thrin": 24000,
@@ -22,5 +31,14 @@
     "abaterate2": 0.25,
     "bstcthresh": 0,
     "bstcabate": 0
+  },
+  "ppl": {
+    "enabled": false,
+    "weekly_rate": 712.17,
+    "max_weeks": 26
+  },
+  "child_support": {
+    "enabled": false,
+    "support_rate": 0.18
   }
 }

--- a/src/parameters_2021-2022.json
+++ b/src/parameters_2021-2022.json
@@ -1,7 +1,18 @@
 {
   "tax_brackets": {
-    "rates": [0.105, 0.175, 0.30, 0.33, 0.39],
-    "thresholds": [14000, 48000, 70000, 180000]
+    "rates": [
+      0.105,
+      0.175,
+      0.30,
+      0.33,
+      0.39
+    ],
+    "thresholds": [
+      14000,
+      48000,
+      70000,
+      180000
+    ]
   },
   "ietc": {
     "thrin": 24000,
@@ -22,5 +33,14 @@
     "abaterate2": 0.27,
     "bstcthresh": 0,
     "bstcabate": 0
+  },
+  "ppl": {
+    "enabled": false,
+    "weekly_rate": 712.17,
+    "max_weeks": 26
+  },
+  "child_support": {
+    "enabled": false,
+    "support_rate": 0.18
   }
 }


### PR DESCRIPTION
## Summary
- add Paid Parental Leave and child support sections to every yearly parameter file
- clarify in README that parameters are present for all years
- note parameter availability in CHANGELOG
- include deps for running tests

## Testing
- `pip install -e .`
- `pip install -r requirements-dev.txt`
- `pre-commit run --files README.md CHANGELOG.md src/parameters_2005-2006.json src/parameters_2006-2007.json src/parameters_2007-2008.json src/parameters_2008-2009.json src/parameters_2009-2010.json src/parameters_2010-2011.json src/parameters_2011-2012.json src/parameters_2012-2013.json src/parameters_2013-2014.json src/parameters_2014-2015.json src/parameters_2015-2016.json src/parameters_2016-2017.json src/parameters_2017-2018.json src/parameters_2018-2019.json src/parameters_2019-2020.json src/parameters_2020-2021.json src/parameters_2021-2022.json`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_688748d261cc833181e83d0d80012963