### PR TITLE
Add module docstring for EVPI utilities

### DIFF
--- a/src/README.md
+++ b/src/README.md
@@ -9,5 +9,6 @@ This directory contains the core Python source code for the NZ Microsimulation M
 *   `wff_microsim.py`: Implements the Working for Families (WFF) microsimulation model (`famsim`).
 *   `wff_microsim_main.py`: A script to run the WFF microsimulation model with sample data.
 *   `payroll_deductions.py`: Helper functions for KiwiSaver contributions and student loan repayments.
+*   `value_of_information.py`: Functions for computing the Expected Value of Perfect Information (EVPI) from probabilistic sensitivity analysis outputs.
 *   `__init__.py`: Makes the `src` directory a Python package.
 *   `py.typed`: Indicates that this package supports type checking.

--- a/src/value_of_information.py
+++ b/src/value_of_information.py
@@ -1,3 +1,5 @@
+"""Value of Information utilities."""
+
 from typing import Dict
 
 import numpy as np
@@ -48,3 +50,6 @@ def calculate_evpi(psa_results: Dict[str, np.ndarray]) -> Dict[str, float]:
         evpi_values[metric] = mean_perfect - mean_current
 
     return evpi_values
+
+
+__all__ = ["calculate_evpi"]


### PR DESCRIPTION
## Summary
- document the value_of_information module
- document EVPI utilities in `src/README.md`

## Testing
- `pre-commit run --files src/value_of_information.py src/README.md`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_688748c25be48331b2d33cfdd4b37c51