### PR TITLE
Add budget impact wrapper in reporting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Moved `LICENSE` file to `docs/` directory.
 - Added `calculate_evpi` function for computing the Expected Value of Perfect Information from probabilistic sensitivity outputs and corresponding unit tests.
 - Added budget impact analysis utilities for comparing baseline and reform scenarios.
+- Added wrapper `calculate_budget_impact` in `src.reporting`.
 - Added `src/acc_levy.py` with ACC levy and payroll deduction functions.
 - New unit tests for ACC levy calculations.
 - Added inequality metrics helpers (`lorenz_curve`, `atkinson_index`, `theil_index`).

--- a/README.md
+++ b/README.md
@@ -103,7 +103,8 @@ The project currently includes parameter files for the following tax years, loca
 ### Budget Impact Analysis
 
 To compare the fiscal outcomes of two scenarios, use
-`calculate_budget_impact` from `src.budget_analysis`:
+`calculate_budget_impact` from either `src.budget_analysis` or the
+`src.reporting` convenience wrapper:
 
 ```python
 import pandas as pd

--- a/src/reporting.py
+++ b/src/reporting.py
@@ -89,6 +89,30 @@ def theil_index(income_series: pd.Series) -> float:
     return calculate_theil_index(income_series)
 
 
+def calculate_budget_impact(baseline_df: pd.DataFrame, reform_df: pd.DataFrame) -> pd.DataFrame:
+    """Return fiscal metrics for baseline and reform scenarios and their difference."""
+    baseline_tax = calculate_total_tax_revenue(baseline_df)
+    baseline_welfare = calculate_total_welfare_transfers(baseline_df)
+    baseline_net = calculate_net_fiscal_impact(baseline_tax, baseline_welfare)
+
+    reform_tax = calculate_total_tax_revenue(reform_df)
+    reform_welfare = calculate_total_welfare_transfers(reform_df)
+    reform_net = calculate_net_fiscal_impact(reform_tax, reform_welfare)
+
+    data = {
+        "Metric": [
+            "Total Tax Revenue",
+            "Total Welfare Transfers",
+            "Net Fiscal Impact",
+        ],
+        "Baseline": [baseline_tax, baseline_welfare, baseline_net],
+        "Reform": [reform_tax, reform_welfare, reform_net],
+    }
+    df = pd.DataFrame(data)
+    df["Difference"] = df["Reform"] - df["Baseline"]
+    return df
+
+
 def generate_microsim_report(simulated_data: pd.DataFrame, report_params: Dict[str, Any]) -> Dict[str, Any]:
     """
     Generates a comprehensive microsimulation report using the defined report components.
@@ -151,5 +175,6 @@ __all__ = [
     "lorenz_curve",
     "atkinson_index",
     "theil_index",
+    "calculate_budget_impact",
     "generate_microsim_report",
 ]


### PR DESCRIPTION
## Summary
- add `calculate_budget_impact` wrapper in `src.reporting`
- expose wrapper via `__all__`
- document new API in README
- note change in CHANGELOG

## Testing
- `pre-commit run --files src/reporting.py CHANGELOG.md README.md`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_688748c21ad08331ba7a7ec3b0de344a