### PR TITLE
ci: use upload-artifact v4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,7 @@ jobs:
         run: tox
 
       - name: Upload coverage report
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: coverage-report-${{ matrix.python-version }}
           path: coverage.xml


### PR DESCRIPTION
## Summary
- use `actions/upload-artifact@v4` in CI to fix workflow failures

## Testing
- `ruff check .` *(fails: Blank line contains whitespace, etc.)*
- `ruff format --check .` *(fails: would reformat src/benefits.py, tests/test_wff_microsim.py)*
- `pytest` *(fails: TypeError: 'Parameters' object is not subscriptable)*

------
https://chatgpt.com/codex/tasks/task_e_688d88e962848331843d687840f83ca8

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the CI pipeline to use the latest version of the artifact upload action for coverage reports.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->