### PR TITLE
ci: add workflow_dispatch trigger to docs workflow

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+  workflow_dispatch:
 
 permissions:
   contents: write


### PR DESCRIPTION
Adds the workflow_dispatch trigger to the docs workflow to allow for manual triggering.