### PR TITLE
fix(ci): use actions-gh-pages to deploy docs

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -23,6 +23,11 @@ jobs:
           python -m pip install --upgrade pip
           pip cache purge
           pip install -r requirements-dev.txt
+      - name: Build docs
+        run: mkdocs build
       - name: Deploy docs
-        run: mkdocs gh-deploy --force
+        uses: peaceiris/actions-gh-pages@v4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./site
       


### PR DESCRIPTION
This PR fixes the documentation deployment by using the peaceiris/actions-gh-pages action, which respects the branch protection rules on the gh-pages branch.