### PR TITLE
fix(ci): use add-paths in docs workflow

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -34,5 +34,5 @@ jobs:
           body: "This PR updates the documentation on the gh-pages branch."
           branch: "docs/gh-pages"
           base: "gh-pages"
-          path: "./site"
+          add-paths: "site/"
       


### PR DESCRIPTION
This PR fixes the docs workflow by using 'add-paths' instead of 'path' to avoid issues with the git context.