### PR TITLE
fix(ci): add missing type stubs for mypy

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,7 +9,7 @@ repos:
     rev: v1.10.0
     hooks:
       - id: mypy
-        additional_dependencies: [pandas, numpy, pydantic, types-requests]
+        additional_dependencies: [pandas, numpy, pydantic, types-requests, types-PyYAML]
   - repo: https://github.com/PyCQA/bandit
     rev: 1.8.6
     hooks:

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -19,3 +19,5 @@ scipy
 seaborn
 tabulate
 tox
+types-PyYAML
+types-requests


### PR DESCRIPTION
This PR adds the missing type stubs for the requests and PyYAML libraries to fix the mypy errors in the CI build.