### PR TITLE
fix(ci): correctly deploy docs to gh-pages with artifacts

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -10,7 +10,7 @@ permissions:
   contents: write
 
 jobs:
-  deploy:
+  build:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -25,14 +25,24 @@ jobs:
           pip install -r requirements-dev.txt
       - name: Build docs
         run: mkdocs build
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: github-pages
+          path: site
+  deploy:
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Download artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: github-pages
       - name: Deploy to GitHub Pages
         uses: peaceiris/actions-gh-pages@v4
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./site
-          # The following lines are needed to ensure that the CNAME file is not deleted
-          # and that the deployment is made to the root of the gh-pages branch.
-          # See https://github.com/peaceiris/actions-gh-pages#%EF%B8%8F-secrets
+          publish_dir: .
           user_name: 'github-actions[bot]'
           user_email: 'github-actions[bot]@users.noreply.github.com'
           commit_message: 'docs: deploy to gh-pages'


### PR DESCRIPTION
This PR fixes the documentation deployment by using artifacts to ensure a clean deployment environment.