### PR TITLE
fix(ci): manually deploy docs to gh-pages

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -39,13 +39,13 @@ jobs:
         with:
           name: github-pages
       - name: Deploy to GitHub Pages
-        uses: peaceiris/actions-gh-pages@v4
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: .
-          user_name: 'github-actions[bot]'
-          user_email: 'github-actions[bot]@users.noreply.github.com'
-          commit_message: 'docs: deploy to gh-pages'
-          publish_branch: gh-pages
-          force_orphan: true
+        run: |
+          git config --global user.name "github-actions[bot]"
+          git config --global user.email "github-actions[bot]@users.noreply.github.com"
+          git clone https://github.com/${{ github.repository }}.git --branch gh-pages --single-branch gh-pages-deploy
+          cp -r site/* gh-pages-deploy/
+          cd gh-pages-deploy
+          git add .
+          git commit -m "docs: deploy to gh-pages"
+          git push --force https://${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}.git gh-pages
       


### PR DESCRIPTION
This PR fixes the documentation deployment by using a manual script to push the built site to the gh-pages branch.