### PR TITLE
Feat: Include documentation in package

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,3 +53,6 @@ disable_error_code = ["var-annotated"]
 
 [tool.coverage.run]
 source = ["src"]
+
+[tool.setuptools.package-data]
+nztaxmicrosim = ["docs/*"]


### PR DESCRIPTION
This PR updates the pyproject.toml to include the docs directory in the published package.