### PR TITLE
Chore: Bump version to 0.1.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "nztaxmicrosim"
-version = "0.1.0"
+version = "0.1.1"
 description = "A Python-based microsimulation model for the New Zealand tax and transfer system."
 readme = "README.md"
 dependencies = [


### PR DESCRIPTION
Bumps the package version to 0.1.1 for a new TestPyPI release.