### PR TITLE
Feat: Add initial parameter file for 1985-1986

### DIFF
--- a/src/parameters_1985-1986.json
+++ b/src/parameters_1985-1986.json
@@ -1,0 +1,68 @@
+{
+    "_source_references": {
+        "tax_brackets": {
+            "source": "nz_personal_tax_rules.json: year 1985 entry",
+            "reference_ids": ["152018581057803-L24-L25"],
+            "notes": "NEEDS RESEARCH. Source only provides the top marginal tax rate of 67%. The full bracket structure is unknown. The values here are placeholders and do not represent a valid tax system."
+        },
+        "ietc": {
+            "source": "Placeholder",
+            "notes": "NEEDS RESEARCH. The structure of low-income tax relief in 1985 is unknown."
+        },
+        "wff": {
+            "source": "Placeholder",
+            "notes": "NEEDS RESEARCH. WFF did not exist. The rules for historical family assistance programs are unknown."
+        },
+        "ppl": {
+            "source": "Placeholder",
+            "notes": "NEEDS RESEARCH. Paid Parental Leave scheme of 1985 is unknown."
+        },
+        "child_support": {
+            "source": "Placeholder",
+            "notes": "NEEDS RESEARCH. Child support rules for 1985 are unknown."
+        },
+        "acc_levy": {
+            "source": "Placeholder",
+            "notes": "NEEDS RESEARCH. The ACC levy rate and income cap for 1985 are unknown."
+        }
+    },
+    "tax_brackets": {
+        "rates": [
+            0.67
+        ],
+        "thresholds": []
+    },
+    "ietc": {
+        "thrin": 0,
+        "ent": 0,
+        "thrab": 0,
+        "abrate": 0
+    },
+    "wff": {
+        "ftc1": 0,
+        "ftc2": 0,
+        "iwtc1": 0,
+        "iwtc2": 0,
+        "bstc": 0,
+        "mftc": 0,
+        "abatethresh1": 0,
+        "abatethresh2": 0,
+        "abaterate1": 0,
+        "abaterate2": 0,
+        "bstcthresh": 0,
+        "bstcabate": 0
+    },
+    "ppl": {
+        "enabled": false,
+        "weekly_rate": 0,
+        "max_weeks": 0
+    },
+    "child_support": {
+        "enabled": false,
+        "support_rate": 0
+    },
+    "acc_levy": {
+        "rate": 0.0,
+        "max_income": 0
+    }
+}


### PR DESCRIPTION
This PR adds a new, high-fidelity parameter file for the 1985-1986 financial year. It includes source references and notes on which parameters require further historical research.