### PR TITLE
feat: Add script to auto-generate parameter documentation

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -4,46 +4,50 @@ This document outlines development priorities for the NZ Microsimulation Model, 
 
 ## Upcoming Tasks
 
-1. **Core Static Personal Income Model**
+1. **Core Static Personal Income Model** ✅
    - *Milestone:* Finalize baseline calculations for individual liabilities and incomes.
    - *Priority:* **High**
+   - *Status:* **Done**
 
-2. **Expand Rule Coverage**
+2. **Expand Rule Coverage** *(In Progress)*
    - *Milestone:* Implement additional personal tax, benefit, and levy rules.
    - *Tasks:*
-     - Child Support payments
-     - Disability Allowance
-     - Taxation of investment income (e.g., PIE funds)
+     - Child Support payments ✅
+     - Disability Allowance ✅
+     - Taxation of investment income (e.g., PIE funds) ✅
      - Tax credits for charitable donations
    - *Priority:* **High**
+   - *Status:* **In Progress**. The next feature is Tax credits for charitable donations.
 
-3. **Modular Simulation Pipeline**
+3. **Modular Simulation Pipeline** ✅
    - *Milestone:* Design plug-in architecture for tax and benefit rules.
    - *Priority:* **High**
+   - *Status:* **Done**
 
-3. **Dynamic Behavioural Extensions**
+4. **Dynamic Behavioural Extensions** *(In Progress)*
    - *Milestone:* Introduce modules that capture behavioural responses and longitudinal impacts of policy changes.
    - *Priority:* **Medium**
+   - *Status:* **In Progress**. A simple dynamic simulation utility exists.
 
-4. **Complete Sensitivity Analysis Tools**
+5. **Complete Sensitivity Analysis Tools** ✅
    - *Milestone:* Finalize parameter sweep utilities and integrate with scenario management.
    - *Priority:* **Medium**
+   - *Status:* **Done**
 
-5. **Budget Impact Modules**
+6. **Budget Impact Modules** ✅
    - *Milestone:* Build routines to aggregate fiscal costs and savings across scenarios.
    - *Priority:* **High**
+   - *Status:* **Done**
 
-6. **Expanded Equity Metrics**
+7. **Expanded Equity Metrics** ✅
    - *Milestone:* Introduce additional indicators of distributional effects (e.g., progressivity indexes).
    - *Priority:* **Medium**
+   - *Status:* **Done**
 
-7. **Modular Simulation Pipeline**
-   - *Milestone:* Allow tax and benefit rules to be assembled via plug-in modules with configurable order and substitution.
-   - *Priority:* **Medium**
-
-8. **Value-of-Information Analysis**
+8. **Value-of-Information Analysis** ✅
    - *Milestone:* Add module for assessing the benefit of additional data sources or improved data quality.
    - *Priority:* **Medium**
+   - *Status:* **Done**
 
 ## Short-Term Milestones
 
@@ -52,18 +56,20 @@ This document outlines development priorities for the NZ Microsimulation Model, 
 
 ## Future Features
 
-10. **Historical Analysis Enhancements**
+9. **Policy Optimisation Module**
+    - *Description:* Introduce a module to search for optimal policy parameters based on user-defined objectives (e.g., maximizing revenue while minimizing inequality).
+    - *Priority:* **Low**
+    - *Status:* **Not Started**
+    - *Implementation Plan:*
+      - **Phase 1: Simple Parameter Scanning:** Develop the core infrastructure to programmatically run the simulation with a grid of different input parameters and save the results. This provides a basic but robust tool for exploring policy options.
+      - **Phase 2: Advanced Optimization:** Integrate a general-purpose optimization library (e.g., Optuna) to intelligently and efficiently search the parameter space for optimal policies, building on the foundation from Phase 1.
+
+10. **Historical Analysis Enhancements** *(In Progress)*
     - *Description:* Improve the model's capability to conduct robust historical analysis by incorporating economic and demographic changes over time.
     - *Tasks:*
       - **Inflation and Wage Adjustment:** Introduce a mechanism to adjust population incomes and monetary values to a common year's terms, enabling meaningful "real terms" comparisons of policy impacts across different eras.
       - **Demographic Evolution:** Develop a module to simulate changes in the population's structure over time (e.g., age distribution, family size), allowing for more realistic long-term analysis.
       - **Historical Reporting Framework:** Create dedicated reporting functions to generate standard outputs for historical comparisons, such as plots of effective tax rates or benefit entitlements by decile over time.
     - *Priority:* **Medium**
-
-9. **Policy Optimisation Module**
-   - *Description:* Introduce a module to search for optimal policy parameters based on user-defined objectives (e.g., maximizing revenue while minimizing inequality).
-   - *Priority:* **Low**
-   - *Implementation Plan:*
-     - **Phase 1: Simple Parameter Scanning:** Develop the core infrastructure to programmatically run the simulation with a grid of different input parameters and save the results. This provides a basic but robust tool for exploring policy options.
-     - **Phase 2: Advanced Optimization:** Integrate a general-purpose optimization library (e.g., Optuna) to intelligently and efficiently search the parameter space for optimal policies, building on the foundation from Phase 1.
+    - *Status:* **In Progress**. Foundational files exist.
 

--- a/docs/parameter_coverage.md
+++ b/docs/parameter_coverage.md
@@ -1,0 +1,6924 @@
+# Parameter Coverage
+
+This page automatically documents the coverage of policy rules across different years, based on the available parameter files.
+
+## Rule Coverage Matrix
+
+| Year | `_source_references` | `acc_levy` | `accommodation_supplement` | `bstc` | `child_support` | `disability_allowance` | `donation_credit` | `family_boost` | `ftc` | `ietc` | `iwtc` | `jss` | `kiwisaver` | `mftc` | `pie` | `ppl` | `rwt` | `slp` | `social_security_levy` | `sps` | `student_loan` | `tax_brackets` | `wep` | `wff` |
+| --- | :---: | :---: | :---: | :---: | :---: | :---: | :---: | :---: | :---: | :---: | :---: | :---: | :---: | :---: | :---: | :---: | :---: | :---: | :---: | :---: | :---: | :---: | :---: | :---: |
+| 1935-1936 | ✅ | ✅ | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ | ❌ | ✅ | ❌ | ❌ | ✅ | ❌ | ✅ |
+| 1936-1937 | ✅ | ✅ | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ | ❌ | ✅ | ❌ | ❌ | ✅ | ❌ | ✅ |
+| 1937-1938 | ✅ | ✅ | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ | ❌ | ✅ | ❌ | ❌ | ✅ | ❌ | ✅ |
+| 1938-1939 | ✅ | ✅ | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ | ❌ | ✅ | ❌ | ❌ | ✅ | ❌ | ✅ |
+| 1939-1940 | ✅ | ✅ | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ | ❌ | ✅ | ❌ | ❌ | ✅ | ❌ | ✅ |
+| 1940-1941 | ✅ | ✅ | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ | ✅ |
+| 1941-1942 | ✅ | ✅ | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ | ✅ |
+| 1942-1943 | ✅ | ✅ | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ | ✅ |
+| 1943-1944 | ✅ | ✅ | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ | ✅ |
+| 1944-1945 | ✅ | ✅ | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ | ✅ |
+| 1945-1946 | ✅ | ✅ | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ | ✅ |
+| 1946-1947 | ✅ | ✅ | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ | ✅ |
+| 1947-1948 | ✅ | ✅ | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ | ✅ |
+| 1948-1949 | ✅ | ✅ | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ | ✅ |
+| 1949-1950 | ✅ | ✅ | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ | ✅ |
+| 1950-1951 | ✅ | ✅ | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ | ✅ |
+| 1951-1952 | ✅ | ✅ | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ | ✅ |
+| 1952-1953 | ✅ | ✅ | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ | ✅ |
+| 1953-1954 | ✅ | ✅ | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ | ✅ |
+| 1954-1955 | ✅ | ✅ | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ | ✅ |
+| 1955-1956 | ✅ | ✅ | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ | ✅ |
+| 1956-1957 | ✅ | ✅ | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ | ✅ |
+| 1957-1958 | ✅ | ✅ | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ | ✅ |
+| 1958-1959 | ✅ | ✅ | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ | ✅ |
+| 1959-1960 | ✅ | ✅ | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ | ✅ |
+| 1960-1961 | ✅ | ✅ | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ | ✅ |
+| 1961-1962 | ✅ | ✅ | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ | ✅ |
+| 1962-1963 | ✅ | ✅ | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ | ✅ |
+| 1963-1964 | ✅ | ✅ | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ | ✅ |
+| 1964-1965 | ✅ | ✅ | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ | ✅ |
+| 1965-1966 | ✅ | ✅ | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ | ✅ |
+| 1966-1967 | ✅ | ✅ | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ | ✅ |
+| 1967-1968 | ✅ | ✅ | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ | ✅ |
+| 1968-1969 | ✅ | ✅ | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ | ✅ |
+| 1969-1970 | ✅ | ✅ | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ | ✅ |
+| 1970-1971 | ✅ | ✅ | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ | ✅ |
+| 1971-1972 | ✅ | ✅ | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ | ✅ |
+| 1972-1973 | ✅ | ✅ | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ | ✅ |
+| 1973-1974 | ✅ | ✅ | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ | ✅ |
+| 1974-1975 | ✅ | ✅ | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ | ✅ |
+| 1975-1976 | ✅ | ✅ | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ | ✅ |
+| 1976-1977 | ✅ | ✅ | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ | ✅ |
+| 1977-1978 | ✅ | ✅ | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ | ✅ |
+| 1978-1979 | ✅ | ✅ | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ | ✅ |
+| 1979-1980 | ✅ | ✅ | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ | ✅ |
+| 1980-1981 | ✅ | ✅ | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ | ✅ |
+| 1981-1982 | ✅ | ✅ | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ | ✅ |
+| 1982-1983 | ✅ | ✅ | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ | ✅ |
+| 1983-1984 | ✅ | ✅ | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ | ✅ |
+| 1984-1985 | ✅ | ✅ | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ | ✅ |
+| 1985-1986 | ✅ | ✅ | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ | ✅ |
+| 1986-1987 | ✅ | ✅ | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ | ✅ |
+| 1987-1988 | ✅ | ✅ | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ | ✅ |
+| 1988-1989 | ✅ | ✅ | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ | ✅ |
+| 1989-1990 | ✅ | ✅ | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ | ✅ |
+| 1990-1991 | ✅ | ✅ | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ | ✅ |
+| 1991-1992 | ✅ | ✅ | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ | ✅ |
+| 1992-1993 | ✅ | ✅ | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ | ✅ |
+| 1993-1994 | ✅ | ✅ | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ | ✅ |
+| 1994-1995 | ✅ | ✅ | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ | ✅ |
+| 1995-1996 | ✅ | ✅ | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ | ✅ |
+| 1996-1997 | ✅ | ✅ | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ | ✅ |
+| 1997-1998 | ✅ | ✅ | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ | ✅ |
+| 1998-1999 | ✅ | ✅ | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ | ✅ |
+| 1999-2000 | ✅ | ✅ | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ | ✅ |
+| 2000-2001 | ❌ | ✅ | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ | ✅ |
+| 2001-2002 | ✅ | ✅ | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ | ✅ |
+| 2002-2003 | ✅ | ✅ | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ | ✅ |
+| 2003-2004 | ✅ | ✅ | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ | ✅ |
+| 2004-2005 | ✅ | ✅ | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ | ✅ |
+| 2005-2006 | ❌ | ✅ | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ | ✅ |
+| 2006-2007 | ❌ | ✅ | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ | ✅ |
+| 2007-2008 | ❌ | ✅ | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ | ✅ |
+| 2008-2009 | ❌ | ✅ | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ | ✅ |
+| 2009-2010 | ❌ | ✅ | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ | ✅ |
+| 2010-2011 | ❌ | ✅ | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ | ✅ |
+| 2011-2012 | ❌ | ✅ | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ | ✅ |
+| 2012-2013 | ❌ | ✅ | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ | ✅ |
+| 2013-2014 | ❌ | ✅ | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ | ✅ |
+| 2014-2015 | ❌ | ✅ | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ | ✅ |
+| 2015-2016 | ❌ | ✅ | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ | ✅ |
+| 2016-2017 | ❌ | ✅ | ✅ | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ | ✅ | ❌ | ❌ | ❌ | ✅ | ❌ | ✅ | ❌ | ✅ | ❌ | ✅ | ❌ | ✅ |
+| 2017-2018 | ❌ | ✅ | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ | ✅ |
+| 2018-2019 | ❌ | ✅ | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ | ✅ |
+| 2019-2020 | ❌ | ✅ | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ | ✅ |
+| 2020-2021 | ❌ | ✅ | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ | ✅ |
+| 2021-2022 | ❌ | ✅ | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ | ✅ |
+| 2022-2023 | ❌ | ✅ | ✅ | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ | ✅ | ✅ | ❌ | ❌ | ✅ | ❌ | ✅ | ❌ | ✅ | ✅ | ✅ | ❌ | ✅ |
+| 2023-2024 | ❌ | ✅ | ✅ | ✅ | ✅ | ❌ | ❌ | ❌ | ✅ | ✅ | ✅ | ✅ | ❌ | ✅ | ❌ | ✅ | ✅ | ✅ | ❌ | ✅ | ❌ | ✅ | ✅ | ✅ |
+| 2024-2025 | ❌ | ✅ | ✅ | ❌ | ✅ | ✅ | ✅ | ✅ | ❌ | ✅ | ❌ | ✅ | ✅ | ❌ | ✅ | ✅ | ❌ | ✅ | ❌ | ✅ | ✅ | ✅ | ❌ | ✅ |
+
+## Detailed Parameters by Year
+## 1935-1936
+
+### `_source_references`
+
+| Parameter | Value |
+| --- | --- |
+| `tax_brackets` | `{'source': 'nzlii.org', 'reference_ids': [], 'notes': 'NEEDS RESEARCH. The 1935 tax system was complex and multi-tiered. The top rate was 4 shillings and 6 pence in the pound (22.5%). There were additional surcharges and levies not yet modelled.'}` |
+| `ietc` | `{'source': 'Placeholder', 'notes': 'NEEDS RESEARCH. The structure of low-income tax relief in 1935 is unknown.'}` |
+| `wff` | `{'source': 'Placeholder', 'notes': 'NEEDS RESEARCH. WFF did not exist. The rules for historical family assistance programs are unknown.'}` |
+| `ppl` | `{'source': 'Placeholder', 'notes': 'NEEDS RESEARCH. Paid Parental Leave scheme of 1935 is unknown.'}` |
+| `child_support` | `{'source': 'Placeholder', 'notes': 'NEEDS RESEARCH. Child support rules for 1935 is unknown.'}` |
+| `acc_levy` | `{'source': 'Placeholder', 'notes': 'NEEDS RESEARCH. The ACC levy rate and income cap for 1935 are unknown.'}` |
+| `social_security_levy` | `{'source': 'teara.govt.nz', 'notes': 'An emergency unemployment fund tax of 3.33% was in place.'}` |
+
+
+### `tax_brackets`
+
+| Parameter | Value |
+| --- | --- |
+| `rates` | `[0.225]` |
+| `thresholds` | `[]` |
+
+
+### `ietc`
+
+| Parameter | Value |
+| --- | --- |
+| `thrin` | `0` |
+| `ent` | `0` |
+| `thrab` | `0` |
+| `abrate` | `0` |
+
+
+### `wff`
+
+| Parameter | Value |
+| --- | --- |
+| `ftc1` | `0` |
+| `ftc2` | `0` |
+| `iwtc1` | `0` |
+| `iwtc2` | `0` |
+| `bstc` | `0` |
+| `mftc` | `0` |
+| `abatethresh1` | `0` |
+| `abatethresh2` | `0` |
+| `abaterate1` | `0` |
+| `abaterate2` | `0` |
+| `bstcthresh` | `0` |
+| `bstcabate` | `0` |
+
+
+### `ppl`
+
+| Parameter | Value |
+| --- | --- |
+| `enabled` | `False` |
+| `weekly_rate` | `0` |
+| `max_weeks` | `0` |
+
+
+### `child_support`
+
+| Parameter | Value |
+| --- | --- |
+| `enabled` | `False` |
+| `support_rate` | `0` |
+
+
+### `acc_levy`
+
+| Parameter | Value |
+| --- | --- |
+| `rate` | `0.0` |
+| `max_income` | `0` |
+
+
+### `social_security_levy`
+
+| Parameter | Value |
+| --- | --- |
+| `rate` | `0.0333` |
+
+
+## 1936-1937
+
+### `_source_references`
+
+| Parameter | Value |
+| --- | --- |
+| `tax_brackets` | `{'source': 'teara.govt.nz', 'reference_ids': [], 'notes': 'NEEDS RESEARCH. Source only provides the top marginal tax rate of 42.9%. The full bracket structure is unknown. The values here are placeholders and do not represent a valid tax system.'}` |
+| `ietc` | `{'source': 'Placeholder', 'notes': 'NEEDS RESEARCH. The structure of low-income tax relief in 1939 is unknown.'}` |
+| `wff` | `{'source': 'Placeholder', 'notes': 'NEEDS RESEARCH. WFF did not exist. The rules for historical family assistance programs are unknown.'}` |
+| `ppl` | `{'source': 'Placeholder', 'notes': 'NEEDS RESEARCH. Paid Parental Leave scheme of 1939 is unknown.'}` |
+| `child_support` | `{'source': 'Placeholder', 'notes': 'NEEDS RESEARCH. Child support rules for 1939 is unknown.'}` |
+| `acc_levy` | `{'source': 'Placeholder', 'notes': 'NEEDS RESEARCH. The ACC levy rate and income cap for 1939 are unknown.'}` |
+| `social_security_levy` | `{'source': 'treasury.govt.nz', 'notes': 'An Emergency Unemployment Charge of 1.25% on all income was in place.'}` |
+
+
+### `tax_brackets`
+
+| Parameter | Value |
+| --- | --- |
+| `rates` | `[0.4083]` |
+| `thresholds` | `[]` |
+
+
+### `ietc`
+
+| Parameter | Value |
+| --- | --- |
+| `thrin` | `0` |
+| `ent` | `0` |
+| `thrab` | `0` |
+| `abrate` | `0` |
+
+
+### `wff`
+
+| Parameter | Value |
+| --- | --- |
+| `ftc1` | `0` |
+| `ftc2` | `0` |
+| `iwtc1` | `0` |
+| `iwtc2` | `0` |
+| `bstc` | `0` |
+| `mftc` | `0` |
+| `abatethresh1` | `0` |
+| `abatethresh2` | `0` |
+| `abaterate1` | `0` |
+| `abaterate2` | `0` |
+| `bstcthresh` | `0` |
+| `bstcabate` | `0` |
+
+
+### `ppl`
+
+| Parameter | Value |
+| --- | --- |
+| `enabled` | `False` |
+| `weekly_rate` | `0` |
+| `max_weeks` | `0` |
+
+
+### `child_support`
+
+| Parameter | Value |
+| --- | --- |
+| `enabled` | `False` |
+| `support_rate` | `0` |
+
+
+### `acc_levy`
+
+| Parameter | Value |
+| --- | --- |
+| `rate` | `0.0` |
+| `max_income` | `0` |
+
+
+### `social_security_levy`
+
+| Parameter | Value |
+| --- | --- |
+| `rate` | `0.0125` |
+
+
+## 1937-1938
+
+### `_source_references`
+
+| Parameter | Value |
+| --- | --- |
+| `tax_brackets` | `{'source': 'teara.govt.nz', 'reference_ids': [], 'notes': 'NEEDS RESEARCH. Source only provides the top marginal tax rate of 42.9%. The full bracket structure is unknown. The values here are placeholders and do not represent a valid tax system.'}` |
+| `ietc` | `{'source': 'Placeholder', 'notes': 'NEEDS RESEARCH. The structure of low-income tax relief in 1939 is unknown.'}` |
+| `wff` | `{'source': 'Placeholder', 'notes': 'NEEDS RESEARCH. WFF did not exist. The rules for historical family assistance programs are unknown.'}` |
+| `ppl` | `{'source': 'Placeholder', 'notes': 'NEEDS RESEARCH. Paid Parental Leave scheme of 1939 is unknown.'}` |
+| `child_support` | `{'source': 'Placeholder', 'notes': 'NEEDS RESEARCH. Child support rules for 1939 is unknown.'}` |
+| `acc_levy` | `{'source': 'Placeholder', 'notes': 'NEEDS RESEARCH. The ACC levy rate and income cap for 1939 are unknown.'}` |
+| `social_security_levy` | `{'source': 'treasury.govt.nz', 'notes': 'An Emergency Unemployment Charge of 1.25% on all income was in place.'}` |
+
+
+### `tax_brackets`
+
+| Parameter | Value |
+| --- | --- |
+| `rates` | `[0.429]` |
+| `thresholds` | `[]` |
+
+
+### `ietc`
+
+| Parameter | Value |
+| --- | --- |
+| `thrin` | `0` |
+| `ent` | `0` |
+| `thrab` | `0` |
+| `abrate` | `0` |
+
+
+### `wff`
+
+| Parameter | Value |
+| --- | --- |
+| `ftc1` | `0` |
+| `ftc2` | `0` |
+| `iwtc1` | `0` |
+| `iwtc2` | `0` |
+| `bstc` | `0` |
+| `mftc` | `0` |
+| `abatethresh1` | `0` |
+| `abatethresh2` | `0` |
+| `abaterate1` | `0` |
+| `abaterate2` | `0` |
+| `bstcthresh` | `0` |
+| `bstcabate` | `0` |
+
+
+### `ppl`
+
+| Parameter | Value |
+| --- | --- |
+| `enabled` | `False` |
+| `weekly_rate` | `0` |
+| `max_weeks` | `0` |
+
+
+### `child_support`
+
+| Parameter | Value |
+| --- | --- |
+| `enabled` | `False` |
+| `support_rate` | `0` |
+
+
+### `acc_levy`
+
+| Parameter | Value |
+| --- | --- |
+| `rate` | `0.0` |
+| `max_income` | `0` |
+
+
+### `social_security_levy`
+
+| Parameter | Value |
+| --- | --- |
+| `rate` | `0.0125` |
+
+
+## 1938-1939
+
+### `_source_references`
+
+| Parameter | Value |
+| --- | --- |
+| `tax_brackets` | `{'source': 'teara.govt.nz', 'reference_ids': [], 'notes': 'NEEDS RESEARCH. Source only provides the top marginal tax rate of 42.9%. The full bracket structure is unknown. The values here are placeholders and do not represent a valid tax system.'}` |
+| `ietc` | `{'source': 'Placeholder', 'notes': 'NEEDS RESEARCH. The structure of low-income tax relief in 1939 is unknown.'}` |
+| `wff` | `{'source': 'Placeholder', 'notes': 'NEEDS RESEARCH. WFF did not exist. The rules for historical family assistance programs are unknown.'}` |
+| `ppl` | `{'source': 'Placeholder', 'notes': 'NEEDS RESEARCH. Paid Parental Leave scheme of 1939 is unknown.'}` |
+| `child_support` | `{'source': 'Placeholder', 'notes': 'NEEDS RESEARCH. Child support rules for 1939 is unknown.'}` |
+| `acc_levy` | `{'source': 'Placeholder', 'notes': 'NEEDS RESEARCH. The ACC levy rate and income cap for 1939 are unknown.'}` |
+| `social_security_levy` | `{'source': 'nzae.org.nz', 'notes': 'An employment promotion charge of 8 pence in the pound was levied on incomes for the 1938–39 fiscal year. This is equivalent to 3.33%.'}` |
+
+
+### `tax_brackets`
+
+| Parameter | Value |
+| --- | --- |
+| `rates` | `[0.429]` |
+| `thresholds` | `[]` |
+
+
+### `ietc`
+
+| Parameter | Value |
+| --- | --- |
+| `thrin` | `0` |
+| `ent` | `0` |
+| `thrab` | `0` |
+| `abrate` | `0` |
+
+
+### `wff`
+
+| Parameter | Value |
+| --- | --- |
+| `ftc1` | `0` |
+| `ftc2` | `0` |
+| `iwtc1` | `0` |
+| `iwtc2` | `0` |
+| `bstc` | `0` |
+| `mftc` | `0` |
+| `abatethresh1` | `0` |
+| `abatethresh2` | `0` |
+| `abaterate1` | `0` |
+| `abaterate2` | `0` |
+| `bstcthresh` | `0` |
+| `bstcabate` | `0` |
+
+
+### `ppl`
+
+| Parameter | Value |
+| --- | --- |
+| `enabled` | `False` |
+| `weekly_rate` | `0` |
+| `max_weeks` | `0` |
+
+
+### `child_support`
+
+| Parameter | Value |
+| --- | --- |
+| `enabled` | `False` |
+| `support_rate` | `0` |
+
+
+### `acc_levy`
+
+| Parameter | Value |
+| --- | --- |
+| `rate` | `0.0` |
+| `max_income` | `0` |
+
+
+### `social_security_levy`
+
+| Parameter | Value |
+| --- | --- |
+| `rate` | `0.0333` |
+
+
+## 1939-1940
+
+### `_source_references`
+
+| Parameter | Value |
+| --- | --- |
+| `tax_brackets` | `{'source': 'teara.govt.nz', 'reference_ids': [], 'notes': 'NEEDS RESEARCH. Source only provides the top marginal tax rate of 42.9%. The full bracket structure is unknown. The values here are placeholders and do not represent a valid tax system.'}` |
+| `ietc` | `{'source': 'Placeholder', 'notes': 'NEEDS RESEARCH. The structure of low-income tax relief in 1939 is unknown.'}` |
+| `wff` | `{'source': 'Placeholder', 'notes': 'NEEDS RESEARCH. WFF did not exist. The rules for historical family assistance programs are unknown.'}` |
+| `ppl` | `{'source': 'Placeholder', 'notes': 'NEEDS RESEARCH. Paid Parental Leave scheme of 1939 is unknown.'}` |
+| `child_support` | `{'source': 'Placeholder', 'notes': 'NEEDS RESEARCH. Child support rules for 1939 is unknown.'}` |
+| `acc_levy` | `{'source': 'Placeholder', 'notes': 'NEEDS RESEARCH. The ACC levy rate and income cap for 1939 are unknown.'}` |
+| `social_security_levy` | `{'source': 'teara.govt.nz', 'notes': 'A 5% social security tax was levied on all income.'}` |
+
+
+### `tax_brackets`
+
+| Parameter | Value |
+| --- | --- |
+| `rates` | `[0.429]` |
+| `thresholds` | `[]` |
+
+
+### `ietc`
+
+| Parameter | Value |
+| --- | --- |
+| `thrin` | `0` |
+| `ent` | `0` |
+| `thrab` | `0` |
+| `abrate` | `0` |
+
+
+### `wff`
+
+| Parameter | Value |
+| --- | --- |
+| `ftc1` | `0` |
+| `ftc2` | `0` |
+| `iwtc1` | `0` |
+| `iwtc2` | `0` |
+| `bstc` | `0` |
+| `mftc` | `0` |
+| `abatethresh1` | `0` |
+| `abatethresh2` | `0` |
+| `abaterate1` | `0` |
+| `abaterate2` | `0` |
+| `bstcthresh` | `0` |
+| `bstcabate` | `0` |
+
+
+### `ppl`
+
+| Parameter | Value |
+| --- | --- |
+| `enabled` | `False` |
+| `weekly_rate` | `0` |
+| `max_weeks` | `0` |
+
+
+### `child_support`
+
+| Parameter | Value |
+| --- | --- |
+| `enabled` | `False` |
+| `support_rate` | `0` |
+
+
+### `acc_levy`
+
+| Parameter | Value |
+| --- | --- |
+| `rate` | `0.0` |
+| `max_income` | `0` |
+
+
+### `social_security_levy`
+
+| Parameter | Value |
+| --- | --- |
+| `rate` | `0.05` |
+
+
+## 1940-1941
+
+### `_source_references`
+
+| Parameter | Value |
+| --- | --- |
+| `tax_brackets` | `{'source': 'nz_personal_tax_rules.json: year 1955 entry', 'reference_ids': ['152018581057803-L17-L19'], 'notes': 'NEEDS RESEARCH. Source only provides the top marginal tax rate of 68%. The full bracket structure is unknown. The values here are placeholders and do not represent a valid tax system.'}` |
+| `ietc` | `{'source': 'Placeholder', 'notes': 'NEEDS RESEARCH. The structure of low-income tax relief in 1955 is unknown.'}` |
+| `wff` | `{'source': 'Placeholder', 'notes': 'NEEDS RESEARCH. WFF did not exist. The rules for historical family assistance programs are unknown.'}` |
+| `ppl` | `{'source': 'Placeholder', 'notes': 'NEEDS RESEARCH. Paid Parental Leave scheme of 1955 is unknown.'}` |
+| `child_support` | `{'source': 'Placeholder', 'notes': 'NEEDS RESEARCH. Child support rules for 1955 is unknown.'}` |
+| `acc_levy` | `{'source': 'Placeholder', 'notes': 'NEEDS RESEARCH. The ACC levy rate and income cap for 1955 are unknown.'}` |
+
+
+### `tax_brackets`
+
+| Parameter | Value |
+| --- | --- |
+| `rates` | `[0.68]` |
+| `thresholds` | `[]` |
+
+
+### `ietc`
+
+| Parameter | Value |
+| --- | --- |
+| `thrin` | `0` |
+| `ent` | `0` |
+| `thrab` | `0` |
+| `abrate` | `0` |
+
+
+### `wff`
+
+| Parameter | Value |
+| --- | --- |
+| `ftc1` | `0` |
+| `ftc2` | `0` |
+| `iwtc1` | `0` |
+| `iwtc2` | `0` |
+| `bstc` | `0` |
+| `mftc` | `0` |
+| `abatethresh1` | `0` |
+| `abatethresh2` | `0` |
+| `abaterate1` | `0` |
+| `abaterate2` | `0` |
+| `bstcthresh` | `0` |
+| `bstcabate` | `0` |
+
+
+### `ppl`
+
+| Parameter | Value |
+| --- | --- |
+| `enabled` | `False` |
+| `weekly_rate` | `0` |
+| `max_weeks` | `0` |
+
+
+### `child_support`
+
+| Parameter | Value |
+| --- | --- |
+| `enabled` | `False` |
+| `support_rate` | `0` |
+
+
+### `acc_levy`
+
+| Parameter | Value |
+| --- | --- |
+| `rate` | `0.0` |
+| `max_income` | `0` |
+
+
+## 1941-1942
+
+### `_source_references`
+
+| Parameter | Value |
+| --- | --- |
+| `tax_brackets` | `{'source': "Gemini Web Search, 2025-08-10, 'New Zealand income tax rates 1941'", 'reference_ids': [], 'notes': 'NEEDS RESEARCH. The full bracket structure is unknown. The values here are approximations based on search results indicating a 12.5% rate for low earners and a 90% top rate. The threshold is an assumption.'}` |
+| `ietc` | `{'source': 'Placeholder', 'notes': "NEEDS RESEARCH. The structure of low-income tax relief in 1941 is unknown, though sources suggest the system was 'friendly to families'."}` |
+| `wff` | `{'source': 'Placeholder', 'notes': 'NEEDS RESEARCH. WFF did not exist. The rules for historical family assistance programs are unknown.'}` |
+| `ppl` | `{'source': 'Placeholder', 'notes': 'NEEDS RESEARCH. Paid Parental Leave scheme of 1941 is unknown.'}` |
+| `child_support` | `{'source': 'Placeholder', 'notes': 'NEEDS RESEARCH. Child support rules for 1941 is unknown.'}` |
+| `acc_levy` | `{'source': "Gemini Web Search, 2025-08-10, 'New Zealand income tax rates 1941'", 'notes': "This is a representation of the 'National Security Tax' of 7.5% (1 shilling and 6 pence in the pound). The name 'acc_levy' is used due to the current data structure. There was no income cap mentioned for this tax."}` |
+
+
+### `tax_brackets`
+
+| Parameter | Value |
+| --- | --- |
+| `rates` | `[0.125, 0.9]` |
+| `thresholds` | `[300]` |
+
+
+### `ietc`
+
+| Parameter | Value |
+| --- | --- |
+| `thrin` | `0` |
+| `ent` | `0` |
+| `thrab` | `0` |
+| `abrate` | `0` |
+
+
+### `wff`
+
+| Parameter | Value |
+| --- | --- |
+| `ftc1` | `0` |
+| `ftc2` | `0` |
+| `iwtc1` | `0` |
+| `iwtc2` | `0` |
+| `bstc` | `0` |
+| `mftc` | `0` |
+| `abatethresh1` | `0` |
+| `abatethresh2` | `0` |
+| `abaterate1` | `0` |
+| `abaterate2` | `0` |
+| `bstcthresh` | `0` |
+| `bstcabate` | `0` |
+
+
+### `ppl`
+
+| Parameter | Value |
+| --- | --- |
+| `enabled` | `False` |
+| `weekly_rate` | `0` |
+| `max_weeks` | `0` |
+
+
+### `child_support`
+
+| Parameter | Value |
+| --- | --- |
+| `enabled` | `False` |
+| `support_rate` | `0` |
+
+
+### `acc_levy`
+
+| Parameter | Value |
+| --- | --- |
+| `rate` | `0.075` |
+| `max_income` | `999999` |
+
+
+## 1942-1943
+
+### `_source_references`
+
+| Parameter | Value |
+| --- | --- |
+| `tax_brackets` | `{'source': "Gemini Web Search, 2025-08-10, 'New Zealand income tax rates 1942'", 'reference_ids': [], 'notes': 'NEEDS RESEARCH. The full bracket structure is unknown. The values here are approximations based on search results indicating a 12.5% rate for low earners and a 90% top rate. The threshold is an assumption.'}` |
+| `ietc` | `{'source': 'Placeholder', 'notes': "NEEDS RESEARCH. The structure of low-income tax relief in 1942 is unknown, though sources suggest the system was 'friendly to families'."}` |
+| `wff` | `{'source': 'Placeholder', 'notes': 'NEEDS RESEARCH. WFF did not exist. The rules for historical family assistance programs are unknown.'}` |
+| `ppl` | `{'source': 'Placeholder', 'notes': 'NEEDS RESEARCH. Paid Parental Leave scheme of 1942 is unknown.'}` |
+| `child_support` | `{'source': 'Placeholder', 'notes': 'NEEDS RESEARCH. Child support rules for 1942 is unknown.'}` |
+| `acc_levy` | `{'source': "Gemini Web Search, 2025-08-10, 'New Zealand income tax rates 1942'", 'notes': "This is a representation of the 'Social Security Tax'. The rate of 7.5% is assumed to be the same as the 'National Security Tax' from 1941. The name 'acc_levy' is used due to the current data structure. There was no income cap mentioned for this tax."}` |
+
+
+### `tax_brackets`
+
+| Parameter | Value |
+| --- | --- |
+| `rates` | `[0.125, 0.9]` |
+| `thresholds` | `[300]` |
+
+
+### `ietc`
+
+| Parameter | Value |
+| --- | --- |
+| `thrin` | `0` |
+| `ent` | `0` |
+| `thrab` | `0` |
+| `abrate` | `0` |
+
+
+### `wff`
+
+| Parameter | Value |
+| --- | --- |
+| `ftc1` | `0` |
+| `ftc2` | `0` |
+| `iwtc1` | `0` |
+| `iwtc2` | `0` |
+| `bstc` | `0` |
+| `mftc` | `0` |
+| `abatethresh1` | `0` |
+| `abatethresh2` | `0` |
+| `abaterate1` | `0` |
+| `abaterate2` | `0` |
+| `bstcthresh` | `0` |
+| `bstcabate` | `0` |
+
+
+### `ppl`
+
+| Parameter | Value |
+| --- | --- |
+| `enabled` | `False` |
+| `weekly_rate` | `0` |
+| `max_weeks` | `0` |
+
+
+### `child_support`
+
+| Parameter | Value |
+| --- | --- |
+| `enabled` | `False` |
+| `support_rate` | `0` |
+
+
+### `acc_levy`
+
+| Parameter | Value |
+| --- | --- |
+| `rate` | `0.075` |
+| `max_income` | `999999` |
+
+
+## 1943-1944
+
+### `_source_references`
+
+| Parameter | Value |
+| --- | --- |
+| `tax_brackets` | `{'source': "Gemini Web Search, 2025-08-10, 'New Zealand income tax rates 1943'", 'reference_ids': [], 'notes': 'NEEDS RESEARCH. The full bracket structure is unknown. The values here are approximations based on search results indicating a 90% top rate. A 12.5% rate for low earners is assumed as a proxy. The threshold is an assumption.'}` |
+| `ietc` | `{'source': 'Placeholder', 'notes': 'NEEDS RESEARCH. The structure of low-income tax relief in 1943 is unknown, though sources suggest low-income earners paid little to no income tax.'}` |
+| `wff` | `{'source': 'Placeholder', 'notes': 'NEEDS RESEARCH. WFF did not exist. The rules for historical family assistance programs are unknown.'}` |
+| `ppl` | `{'source': 'Placeholder', 'notes': 'NEEDS RESEARCH. Paid Parental Leave scheme of 1943 is unknown.'}` |
+| `child_support` | `{'source': 'Placeholder', 'notes': 'NEEDS RESEARCH. Child support rules for 1943 is unknown.'}` |
+| `acc_levy` | `{'source': "Gemini Web Search, 2025-08-10, 'New Zealand income tax rates 1943'", 'notes': "This is a representation of the 'Social Security Tax' which rose to 12.5% in 1943. The name 'acc_levy' is used due to the current data structure. There was no income cap mentioned for this tax."}` |
+
+
+### `tax_brackets`
+
+| Parameter | Value |
+| --- | --- |
+| `rates` | `[0.125, 0.9]` |
+| `thresholds` | `[300]` |
+
+
+### `ietc`
+
+| Parameter | Value |
+| --- | --- |
+| `thrin` | `0` |
+| `ent` | `0` |
+| `thrab` | `0` |
+| `abrate` | `0` |
+
+
+### `wff`
+
+| Parameter | Value |
+| --- | --- |
+| `ftc1` | `0` |
+| `ftc2` | `0` |
+| `iwtc1` | `0` |
+| `iwtc2` | `0` |
+| `bstc` | `0` |
+| `mftc` | `0` |
+| `abatethresh1` | `0` |
+| `abatethresh2` | `0` |
+| `abaterate1` | `0` |
+| `abaterate2` | `0` |
+| `bstcthresh` | `0` |
+| `bstcabate` | `0` |
+
+
+### `ppl`
+
+| Parameter | Value |
+| --- | --- |
+| `enabled` | `False` |
+| `weekly_rate` | `0` |
+| `max_weeks` | `0` |
+
+
+### `child_support`
+
+| Parameter | Value |
+| --- | --- |
+| `enabled` | `False` |
+| `support_rate` | `0` |
+
+
+### `acc_levy`
+
+| Parameter | Value |
+| --- | --- |
+| `rate` | `0.125` |
+| `max_income` | `999999` |
+
+
+## 1944-1945
+
+### `_source_references`
+
+| Parameter | Value |
+| --- | --- |
+| `tax_brackets` | `{'source': "Gemini Web Search, 2025-08-10, 'New Zealand income tax rates 1944'", 'reference_ids': [], 'notes': 'NEEDS RESEARCH. The full bracket structure is unknown. The values here are approximations based on search results indicating a 90% top rate. A 12.5% rate for low earners is assumed as a proxy. The threshold is an assumption.'}` |
+| `ietc` | `{'source': 'Placeholder', 'notes': 'NEEDS RESEARCH. The structure of low-income tax relief in 1944 is unknown, though sources suggest the working class paid little to no income tax.'}` |
+| `wff` | `{'source': 'Placeholder', 'notes': 'NEEDS RESEARCH. WFF did not exist. The rules for historical family assistance programs are unknown.'}` |
+| `ppl` | `{'source': 'Placeholder', 'notes': 'NEEDS RESEARCH. Paid Parental Leave scheme of 1944 is unknown.'}` |
+| `child_support` | `{'source': 'Placeholder', 'notes': 'NEEDS RESEARCH. Child support rules for 1944 is unknown.'}` |
+| `acc_levy` | `{'source': "Gemini Web Search, 2025-08-10, 'New Zealand income tax rates 1944'", 'notes': "This is a representation of the 'Social Security Tax' of 12.5%. The name 'acc_levy' is used due to the current data structure. There was no income cap mentioned for this tax."}` |
+
+
+### `tax_brackets`
+
+| Parameter | Value |
+| --- | --- |
+| `rates` | `[0.125, 0.9]` |
+| `thresholds` | `[300]` |
+
+
+### `ietc`
+
+| Parameter | Value |
+| --- | --- |
+| `thrin` | `0` |
+| `ent` | `0` |
+| `thrab` | `0` |
+| `abrate` | `0` |
+
+
+### `wff`
+
+| Parameter | Value |
+| --- | --- |
+| `ftc1` | `0` |
+| `ftc2` | `0` |
+| `iwtc1` | `0` |
+| `iwtc2` | `0` |
+| `bstc` | `0` |
+| `mftc` | `0` |
+| `abatethresh1` | `0` |
+| `abatethresh2` | `0` |
+| `abaterate1` | `0` |
+| `abaterate2` | `0` |
+| `bstcthresh` | `0` |
+| `bstcabate` | `0` |
+
+
+### `ppl`
+
+| Parameter | Value |
+| --- | --- |
+| `enabled` | `False` |
+| `weekly_rate` | `0` |
+| `max_weeks` | `0` |
+
+
+### `child_support`
+
+| Parameter | Value |
+| --- | --- |
+| `enabled` | `False` |
+| `support_rate` | `0` |
+
+
+### `acc_levy`
+
+| Parameter | Value |
+| --- | --- |
+| `rate` | `0.125` |
+| `max_income` | `999999` |
+
+
+## 1945-1946
+
+### `_source_references`
+
+| Parameter | Value |
+| --- | --- |
+| `tax_brackets` | `{'source': "Gemini Web Search, 2025-08-10, 'New Zealand income tax rates 1945'", 'reference_ids': [], 'notes': 'NEEDS RESEARCH. The full bracket structure is unknown. The values here are approximations based on search results indicating a 90% top rate and a 12.5% rate for low earners. The threshold is an assumption.'}` |
+| `ietc` | `{'source': 'Placeholder', 'notes': 'NEEDS RESEARCH. The structure of low-income tax relief in 1945 is unknown.'}` |
+| `wff` | `{'source': 'Placeholder', 'notes': 'NEEDS RESEARCH. WFF did not exist. The rules for historical family assistance programs are unknown.'}` |
+| `ppl` | `{'source': 'Placeholder', 'notes': 'NEEDS RESEARCH. Paid Parental Leave scheme of 1945 is unknown.'}` |
+| `child_support` | `{'source': 'Placeholder', 'notes': 'NEEDS RESEARCH. Child support rules for 1945 is unknown.'}` |
+| `acc_levy` | `{'source': "Gemini Web Search, 2025-08-10, 'New Zealand income tax rates 1945'", 'notes': "This is a representation of the 'Social Security Charge' of 5%. The name 'acc_levy' is used due to the current data structure. There was no income cap mentioned for this tax."}` |
+
+
+### `tax_brackets`
+
+| Parameter | Value |
+| --- | --- |
+| `rates` | `[0.125, 0.9]` |
+| `thresholds` | `[300]` |
+
+
+### `ietc`
+
+| Parameter | Value |
+| --- | --- |
+| `thrin` | `0` |
+| `ent` | `0` |
+| `thrab` | `0` |
+| `abrate` | `0` |
+
+
+### `wff`
+
+| Parameter | Value |
+| --- | --- |
+| `ftc1` | `0` |
+| `ftc2` | `0` |
+| `iwtc1` | `0` |
+| `iwtc2` | `0` |
+| `bstc` | `0` |
+| `mftc` | `0` |
+| `abatethresh1` | `0` |
+| `abatethresh2` | `0` |
+| `abaterate1` | `0` |
+| `abaterate2` | `0` |
+| `bstcthresh` | `0` |
+| `bstcabate` | `0` |
+
+
+### `ppl`
+
+| Parameter | Value |
+| --- | --- |
+| `enabled` | `False` |
+| `weekly_rate` | `0` |
+| `max_weeks` | `0` |
+
+
+### `child_support`
+
+| Parameter | Value |
+| --- | --- |
+| `enabled` | `False` |
+| `support_rate` | `0` |
+
+
+### `acc_levy`
+
+| Parameter | Value |
+| --- | --- |
+| `rate` | `0.05` |
+| `max_income` | `999999` |
+
+
+## 1946-1947
+
+### `_source_references`
+
+| Parameter | Value |
+| --- | --- |
+| `tax_brackets` | `{'source': "Gemini Web Search, 2025-08-10, 'New Zealand income tax rates 1946'", 'reference_ids': [], 'notes': 'NEEDS RESEARCH. The full bracket structure is unknown. The values here are approximations based on search results indicating a 76.5% top rate. The lower rate and threshold are assumptions.'}` |
+| `ietc` | `{'source': 'Placeholder', 'notes': 'NEEDS RESEARCH. The structure of low-income tax relief in 1946 is unknown.'}` |
+| `wff` | `{'source': 'Placeholder', 'notes': 'NEEDS RESEARCH. WFF did not exist. The rules for historical family assistance programs are unknown.'}` |
+| `ppl` | `{'source': 'Placeholder', 'notes': 'NEEDS RESEARCH. Paid Parental Leave scheme of 1946 is unknown.'}` |
+| `child_support` | `{'source': 'Placeholder', 'notes': 'NEEDS RESEARCH. Child support rules for 1946 is unknown.'}` |
+| `acc_levy` | `{'source': "Gemini Web Search, 2025-08-10, 'New Zealand income tax rates 1946'", 'notes': "This represents the combined 'Social Security Charge' (7.5%) and 'National Security Tax' (2.5%). The name 'acc_levy' is used due to the current data structure. There was no income cap mentioned for these taxes."}` |
+
+
+### `tax_brackets`
+
+| Parameter | Value |
+| --- | --- |
+| `rates` | `[0.125, 0.765]` |
+| `thresholds` | `[300]` |
+
+
+### `ietc`
+
+| Parameter | Value |
+| --- | --- |
+| `thrin` | `0` |
+| `ent` | `0` |
+| `thrab` | `0` |
+| `abrate` | `0` |
+
+
+### `wff`
+
+| Parameter | Value |
+| --- | --- |
+| `ftc1` | `0` |
+| `ftc2` | `0` |
+| `iwtc1` | `0` |
+| `iwtc2` | `0` |
+| `bstc` | `0` |
+| `mftc` | `0` |
+| `abatethresh1` | `0` |
+| `abatethresh2` | `0` |
+| `abaterate1` | `0` |
+| `abaterate2` | `0` |
+| `bstcthresh` | `0` |
+| `bstcabate` | `0` |
+
+
+### `ppl`
+
+| Parameter | Value |
+| --- | --- |
+| `enabled` | `False` |
+| `weekly_rate` | `0` |
+| `max_weeks` | `0` |
+
+
+### `child_support`
+
+| Parameter | Value |
+| --- | --- |
+| `enabled` | `False` |
+| `support_rate` | `0` |
+
+
+### `acc_levy`
+
+| Parameter | Value |
+| --- | --- |
+| `rate` | `0.1` |
+| `max_income` | `999999` |
+
+
+## 1947-1948
+
+### `_source_references`
+
+| Parameter | Value |
+| --- | --- |
+| `tax_brackets` | `{'source': "Gemini Web Search, 2025-08-10, 'New Zealand income tax rates 1947'", 'reference_ids': [], 'notes': 'NEEDS RESEARCH. The full bracket structure is unknown. The values here are approximations based on search results indicating a 76.5% top rate. The lower rate and threshold are assumptions.'}` |
+| `ietc` | `{'source': 'Placeholder', 'notes': 'NEEDS RESEARCH. The structure of low-income tax relief in 1947 is unknown.'}` |
+| `wff` | `{'source': 'Placeholder', 'notes': 'NEEDS RESEARCH. WFF did not exist. The rules for historical family assistance programs are unknown.'}` |
+| `ppl` | `{'source': 'Placeholder', 'notes': 'NEEDS RESEARCH. Paid Parental Leave scheme of 1947 is unknown.'}` |
+| `child_support` | `{'source': 'Placeholder', 'notes': 'NEEDS RESEARCH. Child support rules for 1947 is unknown.'}` |
+| `acc_levy` | `{'source': "Gemini Web Search, 2025-08-10, 'New Zealand income tax rates 1947'", 'notes': "This represents the 'Social Security Tax' of 7.5%. The national security tax was abolished in 1947. The name 'acc_levy' is used due to the current data structure. There was no income cap mentioned for this tax."}` |
+
+
+### `tax_brackets`
+
+| Parameter | Value |
+| --- | --- |
+| `rates` | `[0.125, 0.765]` |
+| `thresholds` | `[300]` |
+
+
+### `ietc`
+
+| Parameter | Value |
+| --- | --- |
+| `thrin` | `0` |
+| `ent` | `0` |
+| `thrab` | `0` |
+| `abrate` | `0` |
+
+
+### `wff`
+
+| Parameter | Value |
+| --- | --- |
+| `ftc1` | `0` |
+| `ftc2` | `0` |
+| `iwtc1` | `0` |
+| `iwtc2` | `0` |
+| `bstc` | `0` |
+| `mftc` | `0` |
+| `abatethresh1` | `0` |
+| `abatethresh2` | `0` |
+| `abaterate1` | `0` |
+| `abaterate2` | `0` |
+| `bstcthresh` | `0` |
+| `bstcabate` | `0` |
+
+
+### `ppl`
+
+| Parameter | Value |
+| --- | --- |
+| `enabled` | `False` |
+| `weekly_rate` | `0` |
+| `max_weeks` | `0` |
+
+
+### `child_support`
+
+| Parameter | Value |
+| --- | --- |
+| `enabled` | `False` |
+| `support_rate` | `0` |
+
+
+### `acc_levy`
+
+| Parameter | Value |
+| --- | --- |
+| `rate` | `0.075` |
+| `max_income` | `999999` |
+
+
+## 1948-1949
+
+### `_source_references`
+
+| Parameter | Value |
+| --- | --- |
+| `tax_brackets` | `{'source': "Gemini Web Search, 2025-08-10, 'New Zealand income tax rates 1948'", 'reference_ids': [], 'notes': 'NEEDS RESEARCH. The full bracket structure is unknown. The values here are approximations based on search results indicating a 76.5% top rate. The lower rate and threshold are assumptions.'}` |
+| `ietc` | `{'source': "Gemini Web Search, 2025-08-10, 'New Zealand income tax rates 1948'", 'notes': 'This models the £10 rebate for all taxpayers in 1948.'}` |
+| `wff` | `{'source': 'Placeholder', 'notes': 'NEEDS RESEARCH. WFF did not exist. The rules for historical family assistance programs are unknown.'}` |
+| `ppl` | `{'source': 'Placeholder', 'notes': 'NEEDS RESEARCH. Paid Parental Leave scheme of 1948 is unknown.'}` |
+| `child_support` | `{'source': 'Placeholder', 'notes': 'NEEDS RESEARCH. Child support rules for 1948 is unknown.'}` |
+| `acc_levy` | `{'source': "Gemini Web Search, 2025-08-10, 'New Zealand income tax rates 1948'", 'notes': "This represents the 'Social Security Tax' of 7.5%. The name 'acc_levy' is used due to the current data structure. There was no income cap mentioned for this tax."}` |
+
+
+### `tax_brackets`
+
+| Parameter | Value |
+| --- | --- |
+| `rates` | `[0.125, 0.765]` |
+| `thresholds` | `[300]` |
+
+
+### `ietc`
+
+| Parameter | Value |
+| --- | --- |
+| `thrin` | `0` |
+| `ent` | `10` |
+| `thrab` | `999999` |
+| `abrate` | `0` |
+
+
+### `wff`
+
+| Parameter | Value |
+| --- | --- |
+| `ftc1` | `0` |
+| `ftc2` | `0` |
+| `iwtc1` | `0` |
+| `iwtc2` | `0` |
+| `bstc` | `0` |
+| `mftc` | `0` |
+| `abatethresh1` | `0` |
+| `abatethresh2` | `0` |
+| `abaterate1` | `0` |
+| `abaterate2` | `0` |
+| `bstcthresh` | `0` |
+| `bstcabate` | `0` |
+
+
+### `ppl`
+
+| Parameter | Value |
+| --- | --- |
+| `enabled` | `False` |
+| `weekly_rate` | `0` |
+| `max_weeks` | `0` |
+
+
+### `child_support`
+
+| Parameter | Value |
+| --- | --- |
+| `enabled` | `False` |
+| `support_rate` | `0` |
+
+
+### `acc_levy`
+
+| Parameter | Value |
+| --- | --- |
+| `rate` | `0.075` |
+| `max_income` | `999999` |
+
+
+## 1949-1950
+
+### `_source_references`
+
+| Parameter | Value |
+| --- | --- |
+| `tax_brackets` | `{'source': "Gemini Web Search, 2025-08-10, 'New Zealand income tax rates 1949'", 'reference_ids': [], 'notes': 'NEEDS RESEARCH. The full bracket structure is unknown. The values here are approximations based on search results indicating a 76.5% top rate. The lower rate and threshold are assumptions.'}` |
+| `ietc` | `{'source': 'Placeholder', 'notes': 'The £10 rebate from 1948 is assumed to be a one-off and is not included for 1949.'}` |
+| `wff` | `{'source': 'Placeholder', 'notes': 'NEEDS RESEARCH. WFF did not exist. The rules for historical family assistance programs are unknown.'}` |
+| `ppl` | `{'source': 'Placeholder', 'notes': 'NEEDS RESEARCH. Paid Parental Leave scheme of 1949 is unknown.'}` |
+| `child_support` | `{'source': 'Placeholder', 'notes': 'NEEDS RESEARCH. Child support rules for 1949 is unknown.'}` |
+| `acc_levy` | `{'source': "Gemini Web Search, 2025-08-10, 'New Zealand income tax rates 1949'", 'notes': "This represents the 'Social Security Tax' of 7.5%. The name 'acc_levy' is used due to the current data structure. There was no income cap mentioned for this tax."}` |
+
+
+### `tax_brackets`
+
+| Parameter | Value |
+| --- | --- |
+| `rates` | `[0.125, 0.765]` |
+| `thresholds` | `[300]` |
+
+
+### `ietc`
+
+| Parameter | Value |
+| --- | --- |
+| `thrin` | `0` |
+| `ent` | `0` |
+| `thrab` | `0` |
+| `abrate` | `0` |
+
+
+### `wff`
+
+| Parameter | Value |
+| --- | --- |
+| `ftc1` | `0` |
+| `ftc2` | `0` |
+| `iwtc1` | `0` |
+| `iwtc2` | `0` |
+| `bstc` | `0` |
+| `mftc` | `0` |
+| `abatethresh1` | `0` |
+| `abatethresh2` | `0` |
+| `abaterate1` | `0` |
+| `abaterate2` | `0` |
+| `bstcthresh` | `0` |
+| `bstcabate` | `0` |
+
+
+### `ppl`
+
+| Parameter | Value |
+| --- | --- |
+| `enabled` | `False` |
+| `weekly_rate` | `0` |
+| `max_weeks` | `0` |
+
+
+### `child_support`
+
+| Parameter | Value |
+| --- | --- |
+| `enabled` | `False` |
+| `support_rate` | `0` |
+
+
+### `acc_levy`
+
+| Parameter | Value |
+| --- | --- |
+| `rate` | `0.075` |
+| `max_income` | `999999` |
+
+
+## 1950-1951
+
+### `_source_references`
+
+| Parameter | Value |
+| --- | --- |
+| `tax_brackets` | `{'source': "Gemini Web Search, 2025-08-10, 'New Zealand income tax rates 1950'", 'reference_ids': [], 'notes': 'NEEDS RESEARCH. The full bracket structure is unknown. The values here are approximations based on search results indicating a 76.5% top rate. The lower rate and threshold are assumptions.'}` |
+| `ietc` | `{'source': 'Placeholder', 'notes': 'NEEDS RESEARCH. The structure of low-income tax relief in 1950 is unknown.'}` |
+| `wff` | `{'source': 'Placeholder', 'notes': 'NEEDS RESEARCH. WFF did not exist. The rules for historical family assistance programs are unknown.'}` |
+| `ppl` | `{'source': 'Placeholder', 'notes': 'NEEDS RESEARCH. Paid Parental Leave scheme of 1950 is unknown.'}` |
+| `child_support` | `{'source': 'Placeholder', 'notes': 'NEEDS RESEARCH. Child support rules for 1950 is unknown.'}` |
+| `acc_levy` | `{'source': "Gemini Web Search, 2025-08-10, 'New Zealand income tax rates 1950'", 'notes': "This represents the 'Social Security Income Tax' of 7.5%. The name 'acc_levy' is used due to the current data structure. There was no income cap mentioned for this tax."}` |
+
+
+### `tax_brackets`
+
+| Parameter | Value |
+| --- | --- |
+| `rates` | `[0.125, 0.765]` |
+| `thresholds` | `[300]` |
+
+
+### `ietc`
+
+| Parameter | Value |
+| --- | --- |
+| `thrin` | `0` |
+| `ent` | `0` |
+| `thrab` | `0` |
+| `abrate` | `0` |
+
+
+### `wff`
+
+| Parameter | Value |
+| --- | --- |
+| `ftc1` | `0` |
+| `ftc2` | `0` |
+| `iwtc1` | `0` |
+| `iwtc2` | `0` |
+| `bstc` | `0` |
+| `mftc` | `0` |
+| `abatethresh1` | `0` |
+| `abatethresh2` | `0` |
+| `abaterate1` | `0` |
+| `abaterate2` | `0` |
+| `bstcthresh` | `0` |
+| `bstcabate` | `0` |
+
+
+### `ppl`
+
+| Parameter | Value |
+| --- | --- |
+| `enabled` | `False` |
+| `weekly_rate` | `0` |
+| `max_weeks` | `0` |
+
+
+### `child_support`
+
+| Parameter | Value |
+| --- | --- |
+| `enabled` | `False` |
+| `support_rate` | `0` |
+
+
+### `acc_levy`
+
+| Parameter | Value |
+| --- | --- |
+| `rate` | `0.075` |
+| `max_income` | `999999` |
+
+
+## 1951-1952
+
+### `_source_references`
+
+| Parameter | Value |
+| --- | --- |
+| `tax_brackets` | `{'source': "Gemini Web Search, 2025-08-10, 'New Zealand income tax rates 1954'", 'reference_ids': [], 'notes': 'NEEDS RESEARCH. The full bracket structure is unknown. The values here are approximations based on search results indicating a 12.5% starting rate (2 shillings and 6 pence in the pound) and a 76.5% top rate. The threshold is an assumption.'}` |
+| `ietc` | `{'source': 'Placeholder', 'notes': 'NEEDS RESEARCH. The structure of low-income tax relief in 1951 is unknown.'}` |
+| `wff` | `{'source': 'Placeholder', 'notes': 'NEEDS RESEARCH. WFF did not exist. The rules for historical family assistance programs are unknown.'}` |
+| `ppl` | `{'source': 'Placeholder', 'notes': 'NEEDS RESEARCH. Paid Parental Leave scheme of 1951 is unknown.'}` |
+| `child_support` | `{'source': 'Placeholder', 'notes': 'NEEDS RESEARCH. Child support rules for 1951 is unknown.'}` |
+| `acc_levy` | `{'source': "Gemini Web Search, 2025-08-10, 'New Zealand income tax rates 1951'", 'notes': "This represents the 'Social Security charge' of 7.5%. The name 'acc_levy' is used due to the current data structure. There was no income cap mentioned for this tax."}` |
+
+
+### `tax_brackets`
+
+| Parameter | Value |
+| --- | --- |
+| `rates` | `[0.125, 0.765]` |
+| `thresholds` | `[300]` |
+
+
+### `ietc`
+
+| Parameter | Value |
+| --- | --- |
+| `thrin` | `0` |
+| `ent` | `0` |
+| `thrab` | `0` |
+| `abrate` | `0` |
+
+
+### `wff`
+
+| Parameter | Value |
+| --- | --- |
+| `ftc1` | `0` |
+| `ftc2` | `0` |
+| `iwtc1` | `0` |
+| `iwtc2` | `0` |
+| `bstc` | `0` |
+| `mftc` | `0` |
+| `abatethresh1` | `0` |
+| `abatethresh2` | `0` |
+| `abaterate1` | `0` |
+| `abaterate2` | `0` |
+| `bstcthresh` | `0` |
+| `bstcabate` | `0` |
+
+
+### `ppl`
+
+| Parameter | Value |
+| --- | --- |
+| `enabled` | `False` |
+| `weekly_rate` | `0` |
+| `max_weeks` | `0` |
+
+
+### `child_support`
+
+| Parameter | Value |
+| --- | --- |
+| `enabled` | `False` |
+| `support_rate` | `0` |
+
+
+### `acc_levy`
+
+| Parameter | Value |
+| --- | --- |
+| `rate` | `0.075` |
+| `max_income` | `999999` |
+
+
+## 1952-1953
+
+### `_source_references`
+
+| Parameter | Value |
+| --- | --- |
+| `tax_brackets` | `{'source': "Gemini Web Search, 2025-08-10, 'New Zealand income tax rates 1952'", 'reference_ids': [], 'notes': 'NEEDS RESEARCH. The full bracket structure is unknown. The values here are approximations. The 1952 law specified a complex progressive system that is not supported by this file format. The rates here are the 1951 rates (starting at 12.5%) with a 5% surcharge applied, as mandated by the Land and Income Tax (Annual) Act 1952. The threshold is an assumption.'}` |
+| `ietc` | `{'source': 'Placeholder', 'notes': 'NEEDS RESEARCH. The structure of low-income tax relief in 1952 is unknown.'}` |
+| `wff` | `{'source': 'Placeholder', 'notes': 'NEEDS RESEARCH. WFF did not exist. The rules for historical family assistance programs are unknown.'}` |
+| `ppl` | `{'source': 'Placeholder', 'notes': 'NEEDS RESEARCH. Paid Parental Leave scheme of 1952 is unknown.'}` |
+| `child_support` | `{'source': 'Placeholder', 'notes': 'NEEDS RESEARCH. Child support rules for 1952 is unknown.'}` |
+| `acc_levy` | `{'source': "Gemini Web Search, 2025-08-10, 'New Zealand income tax rates 1951'", 'notes': "This represents the 'Social Security charge' of 7.5%. The 1952 search did not mention a change. The name 'acc_levy' is used due to the current data structure. There was no income cap mentioned for this tax."}` |
+
+
+### `tax_brackets`
+
+| Parameter | Value |
+| --- | --- |
+| `rates` | `[0.13125, 0.80325]` |
+| `thresholds` | `[300]` |
+
+
+### `ietc`
+
+| Parameter | Value |
+| --- | --- |
+| `thrin` | `0` |
+| `ent` | `0` |
+| `thrab` | `0` |
+| `abrate` | `0` |
+
+
+### `wff`
+
+| Parameter | Value |
+| --- | --- |
+| `ftc1` | `0` |
+| `ftc2` | `0` |
+| `iwtc1` | `0` |
+| `iwtc2` | `0` |
+| `bstc` | `0` |
+| `mftc` | `0` |
+| `abatethresh1` | `0` |
+| `abatethresh2` | `0` |
+| `abaterate1` | `0` |
+| `abaterate2` | `0` |
+| `bstcthresh` | `0` |
+| `bstcabate` | `0` |
+
+
+### `ppl`
+
+| Parameter | Value |
+| --- | --- |
+| `enabled` | `False` |
+| `weekly_rate` | `0` |
+| `max_weeks` | `0` |
+
+
+### `child_support`
+
+| Parameter | Value |
+| --- | --- |
+| `enabled` | `False` |
+| `support_rate` | `0` |
+
+
+### `acc_levy`
+
+| Parameter | Value |
+| --- | --- |
+| `rate` | `0.075` |
+| `max_income` | `999999` |
+
+
+## 1953-1954
+
+### `_source_references`
+
+| Parameter | Value |
+| --- | --- |
+| `tax_brackets` | `{'source': "Gemini Web Search, 2025-08-10, 'New Zealand income tax rates 1953'", 'reference_ids': [], 'notes': "NEEDS RESEARCH. The full bracket structure is unknown. The values here are approximations based on search results indicating that rates were 'virtually unaltered' from previous years. The 12.5% starting rate and 76.5% top rate are from the 1951/1954 searches. The threshold is an assumption."}` |
+| `ietc` | `{'source': 'Placeholder', 'notes': 'NEEDS RESEARCH. The structure of low-income tax relief in 1953 is unknown.'}` |
+| `wff` | `{'source': 'Placeholder', 'notes': 'NEEDS RESEARCH. WFF did not exist. The rules for historical family assistance programs are unknown.'}` |
+| `ppl` | `{'source': 'Placeholder', 'notes': 'NEEDS RESEARCH. Paid Parental Leave scheme of 1953 is unknown.'}` |
+| `child_support` | `{'source': 'Placeholder', 'notes': 'NEEDS RESEARCH. Child support rules for 1953 is unknown.'}` |
+| `acc_levy` | `{'source': "Gemini Web Search, 2025-08-10, 'New Zealand income tax rates 1953'", 'notes': "This represents the 'Social Security charge' of 7.5%. The name 'acc_levy' is used due to the current data structure. There was no income cap mentioned for this tax."}` |
+
+
+### `tax_brackets`
+
+| Parameter | Value |
+| --- | --- |
+| `rates` | `[0.125, 0.765]` |
+| `thresholds` | `[300]` |
+
+
+### `ietc`
+
+| Parameter | Value |
+| --- | --- |
+| `thrin` | `0` |
+| `ent` | `0` |
+| `thrab` | `0` |
+| `abrate` | `0` |
+
+
+### `wff`
+
+| Parameter | Value |
+| --- | --- |
+| `ftc1` | `0` |
+| `ftc2` | `0` |
+| `iwtc1` | `0` |
+| `iwtc2` | `0` |
+| `bstc` | `0` |
+| `mftc` | `0` |
+| `abatethresh1` | `0` |
+| `abatethresh2` | `0` |
+| `abaterate1` | `0` |
+| `abaterate2` | `0` |
+| `bstcthresh` | `0` |
+| `bstcabate` | `0` |
+
+
+### `ppl`
+
+| Parameter | Value |
+| --- | --- |
+| `enabled` | `False` |
+| `weekly_rate` | `0` |
+| `max_weeks` | `0` |
+
+
+### `child_support`
+
+| Parameter | Value |
+| --- | --- |
+| `enabled` | `False` |
+| `support_rate` | `0` |
+
+
+### `acc_levy`
+
+| Parameter | Value |
+| --- | --- |
+| `rate` | `0.075` |
+| `max_income` | `999999` |
+
+
+## 1954-1955
+
+### `_source_references`
+
+| Parameter | Value |
+| --- | --- |
+| `tax_brackets` | `{'source': "Gemini Web Search, 2025-08-10, 'New Zealand income tax rates 1954'", 'reference_ids': [], 'notes': 'NEEDS RESEARCH. The full bracket structure is unknown. The values here are approximations based on search results indicating a 15% starting rate (3 shillings in the pound) and a 76.5% top rate. The threshold is an assumption. Personal exemptions were increased in 1954, which is not modelled here.'}` |
+| `ietc` | `{'source': 'Placeholder', 'notes': 'NEEDS RESEARCH. The structure of low-income tax relief in 1954 is unknown. Rebates were absorbed by higher personal exemptions.'}` |
+| `wff` | `{'source': 'Placeholder', 'notes': 'NEEDS RESEARCH. WFF did not exist. The rules for historical family assistance programs are unknown.'}` |
+| `ppl` | `{'source': 'Placeholder', 'notes': 'NEEDS RESEARCH. Paid Parental Leave scheme of 1954 is unknown.'}` |
+| `child_support` | `{'source': 'Placeholder', 'notes': 'NEEDS RESEARCH. Child support rules for 1954 is unknown.'}` |
+| `acc_levy` | `{'source': "Gemini Web Search, 2025-08-10, 'New Zealand income tax rates 1953'", 'notes': "This represents the 'Social Security charge' of 7.5%. The 1954 search did not mention a change. The name 'acc_levy' is used due to the current data structure. There was no income cap mentioned for this tax."}` |
+
+
+### `tax_brackets`
+
+| Parameter | Value |
+| --- | --- |
+| `rates` | `[0.15, 0.765]` |
+| `thresholds` | `[300]` |
+
+
+### `ietc`
+
+| Parameter | Value |
+| --- | --- |
+| `thrin` | `0` |
+| `ent` | `0` |
+| `thrab` | `0` |
+| `abrate` | `0` |
+
+
+### `wff`
+
+| Parameter | Value |
+| --- | --- |
+| `ftc1` | `0` |
+| `ftc2` | `0` |
+| `iwtc1` | `0` |
+| `iwtc2` | `0` |
+| `bstc` | `0` |
+| `mftc` | `0` |
+| `abatethresh1` | `0` |
+| `abatethresh2` | `0` |
+| `abaterate1` | `0` |
+| `abaterate2` | `0` |
+| `bstcthresh` | `0` |
+| `bstcabate` | `0` |
+
+
+### `ppl`
+
+| Parameter | Value |
+| --- | --- |
+| `enabled` | `False` |
+| `weekly_rate` | `0` |
+| `max_weeks` | `0` |
+
+
+### `child_support`
+
+| Parameter | Value |
+| --- | --- |
+| `enabled` | `False` |
+| `support_rate` | `0` |
+
+
+### `acc_levy`
+
+| Parameter | Value |
+| --- | --- |
+| `rate` | `0.075` |
+| `max_income` | `999999` |
+
+
+## 1955-1956
+
+### `_source_references`
+
+| Parameter | Value |
+| --- | --- |
+| `tax_brackets` | `{'source': "Gemini Web Search, 2025-08-10, 'New Zealand income tax rates 1955'", 'reference_ids': [], 'notes': 'The values here are an approximation of the 1955 tax system. The system was a progressive structure with rates increasing by 3 pence for every £100. The rates here include a 20% rebate that was in effect for the 1955-56 tax year. This rebate was capped at £75, which is not modelled here. The top rate of 68% is from the placeholder file and is assumed to be the maximum rate.'}` |
+| `ietc` | `{'source': 'Placeholder', 'notes': 'The 20% tax rebate is modelled in the tax brackets. The £75 cap on the rebate is not modelled.'}` |
+| `wff` | `{'source': 'Placeholder', 'notes': 'NEEDS RESEARCH. WFF did not exist. The rules for historical family assistance programs are unknown.'}` |
+| `ppl` | `{'source': 'Placeholder', 'notes': 'NEEDS RESEARCH. Paid Parental Leave scheme of 1955 is unknown.'}` |
+| `child_support` | `{'source': 'Placeholder', 'notes': 'NEEDS RESEARCH. Child support rules for 1955 is unknown.'}` |
+| `acc_levy` | `{'source': "Gemini Web Search, 2025-08-10, 'New Zealand income tax rates 1955'", 'notes': "This represents the 'Social Security Charge' of 7.5%. The name 'acc_levy' is used due to the current data structure. There was no income cap mentioned for this tax."}` |
+
+
+### `tax_brackets`
+
+| Parameter | Value |
+| --- | --- |
+| `rates` | `[0.1, 0.11, 0.12, 0.13, 0.544]` |
+| `thresholds` | `[100, 200, 300, 400]` |
+
+
+### `ietc`
+
+| Parameter | Value |
+| --- | --- |
+| `thrin` | `0` |
+| `ent` | `0` |
+| `thrab` | `0` |
+| `abrate` | `0` |
+
+
+### `wff`
+
+| Parameter | Value |
+| --- | --- |
+| `ftc1` | `0` |
+| `ftc2` | `0` |
+| `iwtc1` | `0` |
+| `iwtc2` | `0` |
+| `bstc` | `0` |
+| `mftc` | `0` |
+| `abatethresh1` | `0` |
+| `abatethresh2` | `0` |
+| `abaterate1` | `0` |
+| `abaterate2` | `0` |
+| `bstcthresh` | `0` |
+| `bstcabate` | `0` |
+
+
+### `ppl`
+
+| Parameter | Value |
+| --- | --- |
+| `enabled` | `False` |
+| `weekly_rate` | `0` |
+| `max_weeks` | `0` |
+
+
+### `child_support`
+
+| Parameter | Value |
+| --- | --- |
+| `enabled` | `False` |
+| `support_rate` | `0` |
+
+
+### `acc_levy`
+
+| Parameter | Value |
+| --- | --- |
+| `rate` | `0.075` |
+| `max_income` | `999999` |
+
+
+## 1956-1957
+
+### `_source_references`
+
+| Parameter | Value |
+| --- | --- |
+| `tax_brackets` | `{'source': "Gemini Web Search, 2025-08-10, 'New Zealand income tax rates 1956'", 'reference_ids': [], 'notes': 'NEEDS RESEARCH. The full bracket structure is unknown. The values here are approximations based on search results indicating a 15% starting rate and a 76.5% top rate. The threshold is an assumption.'}` |
+| `ietc` | `{'source': 'Placeholder', 'notes': 'NEEDS RESEARCH. The structure of low-income tax relief in 1956 is unknown.'}` |
+| `wff` | `{'source': 'Placeholder', 'notes': 'NEEDS RESEARCH. WFF did not exist. The rules for historical family assistance programs are unknown.'}` |
+| `ppl` | `{'source': 'Placeholder', 'notes': 'NEEDS RESEARCH. Paid Parental Leave scheme of 1956 is unknown.'}` |
+| `child_support` | `{'source': 'Placeholder', 'notes': 'NEEDS RESEARCH. Child support rules for 1956 is unknown.'}` |
+| `acc_levy` | `{'source': "Gemini Web Search, 2025-08-10, 'New Zealand income tax rates 1956'", 'notes': "This represents the 'Social Security Income Tax' of 7.5%. The name 'acc_levy' is used due to the current data structure. There was no income cap mentioned for this tax."}` |
+
+
+### `tax_brackets`
+
+| Parameter | Value |
+| --- | --- |
+| `rates` | `[0.15, 0.765]` |
+| `thresholds` | `[300]` |
+
+
+### `ietc`
+
+| Parameter | Value |
+| --- | --- |
+| `thrin` | `0` |
+| `ent` | `0` |
+| `thrab` | `0` |
+| `abrate` | `0` |
+
+
+### `wff`
+
+| Parameter | Value |
+| --- | --- |
+| `ftc1` | `0` |
+| `ftc2` | `0` |
+| `iwtc1` | `0` |
+| `iwtc2` | `0` |
+| `bstc` | `0` |
+| `mftc` | `0` |
+| `abatethresh1` | `0` |
+| `abatethresh2` | `0` |
+| `abaterate1` | `0` |
+| `abaterate2` | `0` |
+| `bstcthresh` | `0` |
+| `bstcabate` | `0` |
+
+
+### `ppl`
+
+| Parameter | Value |
+| --- | --- |
+| `enabled` | `False` |
+| `weekly_rate` | `0` |
+| `max_weeks` | `0` |
+
+
+### `child_support`
+
+| Parameter | Value |
+| --- | --- |
+| `enabled` | `False` |
+| `support_rate` | `0` |
+
+
+### `acc_levy`
+
+| Parameter | Value |
+| --- | --- |
+| `rate` | `0.075` |
+| `max_income` | `999999` |
+
+
+## 1957-1958
+
+### `_source_references`
+
+| Parameter | Value |
+| --- | --- |
+| `tax_brackets` | `{'source': "Gemini Web Search, 2025-08-10, 'New Zealand income tax rates 1957'", 'reference_ids': [], 'notes': 'The values here are an approximation of the 1957 tax system. The rates are the 1956 rates with a 25% rebate applied. This rebate was capped at £75, which is not modelled here. The top rate of 76.5% is from previous years and is assumed to be the maximum rate.'}` |
+| `ietc` | `{'source': 'Placeholder', 'notes': 'The 25% tax rebate is modelled in the tax brackets. The £75 cap on the rebate is not modelled.'}` |
+| `wff` | `{'source': 'Placeholder', 'notes': 'NEEDS RESEARCH. WFF did not exist. The rules for historical family assistance programs are unknown.'}` |
+| `ppl` | `{'source': 'Placeholder', 'notes': 'NEEDS RESEARCH. Paid Parental Leave scheme of 1957 is unknown.'}` |
+| `child_support` | `{'source': 'Placeholder', 'notes': 'NEEDS RESEARCH. Child support rules for 1957 is unknown.'}` |
+| `acc_levy` | `{'source': "Gemini Web Search, 2025-08-10, 'New Zealand income tax rates 1956'", 'notes': "This represents the 'Social Security Income Tax' of 7.5%. The 1957 search did not mention a change. The name 'acc_levy' is used due to the current data structure. There was no income cap mentioned for this tax."}` |
+
+
+### `tax_brackets`
+
+| Parameter | Value |
+| --- | --- |
+| `rates` | `[0.1125, 0.57375]` |
+| `thresholds` | `[300]` |
+
+
+### `ietc`
+
+| Parameter | Value |
+| --- | --- |
+| `thrin` | `0` |
+| `ent` | `0` |
+| `thrab` | `0` |
+| `abrate` | `0` |
+
+
+### `wff`
+
+| Parameter | Value |
+| --- | --- |
+| `ftc1` | `0` |
+| `ftc2` | `0` |
+| `iwtc1` | `0` |
+| `iwtc2` | `0` |
+| `bstc` | `0` |
+| `mftc` | `0` |
+| `abatethresh1` | `0` |
+| `abatethresh2` | `0` |
+| `abaterate1` | `0` |
+| `abaterate2` | `0` |
+| `bstcthresh` | `0` |
+| `bstcabate` | `0` |
+
+
+### `ppl`
+
+| Parameter | Value |
+| --- | --- |
+| `enabled` | `False` |
+| `weekly_rate` | `0` |
+| `max_weeks` | `0` |
+
+
+### `child_support`
+
+| Parameter | Value |
+| --- | --- |
+| `enabled` | `False` |
+| `support_rate` | `0` |
+
+
+### `acc_levy`
+
+| Parameter | Value |
+| --- | --- |
+| `rate` | `0.075` |
+| `max_income` | `999999` |
+
+
+## 1958-1959
+
+### `_source_references`
+
+| Parameter | Value |
+| --- | --- |
+| `tax_brackets` | `{'source': "Gemini Web Search, 2025-08-10, 'New Zealand income tax rates 1958'", 'reference_ids': [], 'notes': 'NEEDS RESEARCH. The full bracket structure is unknown. The values here are approximations based on search results indicating a reversion to the 1954 tax scale, which had a 15% starting rate and a 76.5% top rate. The threshold is an assumption. The 25% rebate from 1957 was removed.'}` |
+| `ietc` | `{'source': 'Placeholder', 'notes': 'NEEDS RESEARCH. The structure of low-income tax relief in 1958 is unknown.'}` |
+| `wff` | `{'source': 'Placeholder', 'notes': 'NEEDS RESEARCH. WFF did not exist. The rules for historical family assistance programs are unknown.'}` |
+| `ppl` | `{'source': 'Placeholder', 'notes': 'NEEDS RESEARCH. Paid Parental Leave scheme of 1958 is unknown.'}` |
+| `child_support` | `{'source': 'Placeholder', 'notes': 'NEEDS RESEARCH. Child support rules for 1958 is unknown.'}` |
+| `acc_levy` | `{'source': "Gemini Web Search, 2025-08-10, 'New Zealand income tax rates 1956'", 'notes': "This represents the 'Social Security Income Tax' of 7.5%. The 1958 search did not mention a change. The name 'acc_levy' is used due to the current data structure. There was no income cap mentioned for this tax."}` |
+
+
+### `tax_brackets`
+
+| Parameter | Value |
+| --- | --- |
+| `rates` | `[0.15, 0.765]` |
+| `thresholds` | `[300]` |
+
+
+### `ietc`
+
+| Parameter | Value |
+| --- | --- |
+| `thrin` | `0` |
+| `ent` | `0` |
+| `thrab` | `0` |
+| `abrate` | `0` |
+
+
+### `wff`
+
+| Parameter | Value |
+| --- | --- |
+| `ftc1` | `0` |
+| `ftc2` | `0` |
+| `iwtc1` | `0` |
+| `iwtc2` | `0` |
+| `bstc` | `0` |
+| `mftc` | `0` |
+| `abatethresh1` | `0` |
+| `abatethresh2` | `0` |
+| `abaterate1` | `0` |
+| `abaterate2` | `0` |
+| `bstcthresh` | `0` |
+| `bstcabate` | `0` |
+
+
+### `ppl`
+
+| Parameter | Value |
+| --- | --- |
+| `enabled` | `False` |
+| `weekly_rate` | `0` |
+| `max_weeks` | `0` |
+
+
+### `child_support`
+
+| Parameter | Value |
+| --- | --- |
+| `enabled` | `False` |
+| `support_rate` | `0` |
+
+
+### `acc_levy`
+
+| Parameter | Value |
+| --- | --- |
+| `rate` | `0.075` |
+| `max_income` | `999999` |
+
+
+## 1959-1960
+
+### `_source_references`
+
+| Parameter | Value |
+| --- | --- |
+| `tax_brackets` | `{'source': "Gemini Web Search, 2025-08-10, 'New Zealand income tax rates 1959'", 'reference_ids': [], 'notes': 'NEEDS RESEARCH. The full bracket structure is unknown. The values here are approximations based on search results indicating that the 1954 tax scale was still in effect. This scale had a 15% starting rate and a 76.5% top rate. The threshold is an assumption.'}` |
+| `ietc` | `{'source': 'Placeholder', 'notes': 'NEEDS RESEARCH. The structure of low-income tax relief in 1959 is unknown.'}` |
+| `wff` | `{'source': 'Placeholder', 'notes': 'NEEDS RESEARCH. WFF did not exist. The rules for historical family assistance programs are unknown.'}` |
+| `ppl` | `{'source': 'Placeholder', 'notes': 'NEEDS RESEARCH. Paid Parental Leave scheme of 1959 is unknown.'}` |
+| `child_support` | `{'source': 'Placeholder', 'notes': 'NEEDS RESEARCH. Child support rules for 1959 is unknown.'}` |
+| `acc_levy` | `{'source': "Gemini Web Search, 2025-08-10, 'New Zealand income tax rates 1959'", 'notes': "This represents the 'Social Security Income Tax' of 7.5%. The name 'acc_levy' is used due to the current data structure. There was no income cap mentioned for this tax."}` |
+
+
+### `tax_brackets`
+
+| Parameter | Value |
+| --- | --- |
+| `rates` | `[0.15, 0.765]` |
+| `thresholds` | `[300]` |
+
+
+### `ietc`
+
+| Parameter | Value |
+| --- | --- |
+| `thrin` | `0` |
+| `ent` | `0` |
+| `thrab` | `0` |
+| `abrate` | `0` |
+
+
+### `wff`
+
+| Parameter | Value |
+| --- | --- |
+| `ftc1` | `0` |
+| `ftc2` | `0` |
+| `iwtc1` | `0` |
+| `iwtc2` | `0` |
+| `bstc` | `0` |
+| `mftc` | `0` |
+| `abatethresh1` | `0` |
+| `abatethresh2` | `0` |
+| `abaterate1` | `0` |
+| `abaterate2` | `0` |
+| `bstcthresh` | `0` |
+| `bstcabate` | `0` |
+
+
+### `ppl`
+
+| Parameter | Value |
+| --- | --- |
+| `enabled` | `False` |
+| `weekly_rate` | `0` |
+| `max_weeks` | `0` |
+
+
+### `child_support`
+
+| Parameter | Value |
+| --- | --- |
+| `enabled` | `False` |
+| `support_rate` | `0` |
+
+
+### `acc_levy`
+
+| Parameter | Value |
+| --- | --- |
+| `rate` | `0.075` |
+| `max_income` | `999999` |
+
+
+## 1960-1961
+
+### `_source_references`
+
+| Parameter | Value |
+| --- | --- |
+| `tax_brackets` | `{'source': 'nz_personal_tax_rules.json: year 1960 entry', 'reference_ids': ['152018581057803-L18-L20'], 'notes': 'NEEDS RESEARCH. Source only provides the top marginal tax rate of 68%. The full bracket structure is unknown. The values here are placeholders and do not represent a valid tax system.'}` |
+| `ietc` | `{'source': 'Placeholder', 'notes': 'NEEDS RESEARCH. The structure of low-income tax relief in 1960 is unknown.'}` |
+| `wff` | `{'source': 'Placeholder', 'notes': 'NEEDS RESEARCH. WFF did not exist. The rules for historical family assistance programs are unknown.'}` |
+| `ppl` | `{'source': 'Placeholder', 'notes': 'NEEDS RESEARCH. Paid Parental Leave scheme of 1960 is unknown.'}` |
+| `child_support` | `{'source': 'Placeholder', 'notes': 'NEEDS RESEARCH. Child support rules for 1960 is unknown.'}` |
+| `acc_levy` | `{'source': 'Placeholder', 'notes': 'NEEDS RESEARCH. The ACC levy rate and income cap for 1960 are unknown.'}` |
+
+
+### `tax_brackets`
+
+| Parameter | Value |
+| --- | --- |
+| `rates` | `[0.68]` |
+| `thresholds` | `[]` |
+
+
+### `ietc`
+
+| Parameter | Value |
+| --- | --- |
+| `thrin` | `0` |
+| `ent` | `0` |
+| `thrab` | `0` |
+| `abrate` | `0` |
+
+
+### `wff`
+
+| Parameter | Value |
+| --- | --- |
+| `ftc1` | `0` |
+| `ftc2` | `0` |
+| `iwtc1` | `0` |
+| `iwtc2` | `0` |
+| `bstc` | `0` |
+| `mftc` | `0` |
+| `abatethresh1` | `0` |
+| `abatethresh2` | `0` |
+| `abaterate1` | `0` |
+| `abaterate2` | `0` |
+| `bstcthresh` | `0` |
+| `bstcabate` | `0` |
+
+
+### `ppl`
+
+| Parameter | Value |
+| --- | --- |
+| `enabled` | `False` |
+| `weekly_rate` | `0` |
+| `max_weeks` | `0` |
+
+
+### `child_support`
+
+| Parameter | Value |
+| --- | --- |
+| `enabled` | `False` |
+| `support_rate` | `0` |
+
+
+### `acc_levy`
+
+| Parameter | Value |
+| --- | --- |
+| `rate` | `0.0` |
+| `max_income` | `0` |
+
+
+## 1961-1962
+
+### `_source_references`
+
+| Parameter | Value |
+| --- | --- |
+| `tax_brackets` | `{'source': "Gemini Web Search, 2025-08-10, 'New Zealand income tax rates 1961'", 'reference_ids': [], 'notes': "NEEDS RESEARCH. The full bracket structure is unknown. The values here are approximations based on search results indicating a 'slight modification' of the 1954 tax scale. Without further details, the rates are assumed to be the same as 1960. The first £60 of interest income was exempt from taxation, which is not modelled here."}` |
+| `ietc` | `{'source': 'Placeholder', 'notes': 'NEEDS RESEARCH. The structure of low-income tax relief in 1961 is unknown.'}` |
+| `wff` | `{'source': 'Placeholder', 'notes': 'NEEDS RESEARCH. WFF did not exist. The rules for historical family assistance programs are unknown.'}` |
+| `ppl` | `{'source': 'Placeholder', 'notes': 'NEEDS RESEARCH. Paid Parental Leave scheme of 1961 is unknown.'}` |
+| `child_support` | `{'source': 'Placeholder', 'notes': 'NEEDS RESEARCH. Child support rules for 1961 is unknown.'}` |
+| `acc_levy` | `{'source': "Gemini Web Search, 2025-08-10, 'New Zealand income tax rates 1961'", 'notes': "This represents the 'Social Security Income Tax' of 7.5%. An exemption for the first £104 of annual income from this tax was introduced from the 1962 tax year. The name 'acc_levy' is used due to the current data structure. There was no income cap mentioned for this tax."}` |
+
+
+### `tax_brackets`
+
+| Parameter | Value |
+| --- | --- |
+| `rates` | `[0.15, 0.765]` |
+| `thresholds` | `[300]` |
+
+
+### `ietc`
+
+| Parameter | Value |
+| --- | --- |
+| `thrin` | `0` |
+| `ent` | `0` |
+| `thrab` | `0` |
+| `abrate` | `0` |
+
+
+### `wff`
+
+| Parameter | Value |
+| --- | --- |
+| `ftc1` | `0` |
+| `ftc2` | `0` |
+| `iwtc1` | `0` |
+| `iwtc2` | `0` |
+| `bstc` | `0` |
+| `mftc` | `0` |
+| `abatethresh1` | `0` |
+| `abatethresh2` | `0` |
+| `abaterate1` | `0` |
+| `abaterate2` | `0` |
+| `bstcthresh` | `0` |
+| `bstcabate` | `0` |
+
+
+### `ppl`
+
+| Parameter | Value |
+| --- | --- |
+| `enabled` | `False` |
+| `weekly_rate` | `0` |
+| `max_weeks` | `0` |
+
+
+### `child_support`
+
+| Parameter | Value |
+| --- | --- |
+| `enabled` | `False` |
+| `support_rate` | `0` |
+
+
+### `acc_levy`
+
+| Parameter | Value |
+| --- | --- |
+| `rate` | `0.075` |
+| `max_income` | `999999` |
+
+
+## 1962-1963
+
+### `_source_references`
+
+| Parameter | Value |
+| --- | --- |
+| `tax_brackets` | `{'source': "Gemini Web Search, 2025-08-10, 'New Zealand income tax rates 1962'", 'reference_ids': [], 'notes': 'The values here are an approximation of the 1962 tax system. The rates are the 1954 rates with a 5% rebate applied. This rebate was capped at £50, which is not modelled here. The top rate of 76.5% is from previous years and is assumed to be the maximum rate.'}` |
+| `ietc` | `{'source': 'Placeholder', 'notes': 'The 5% tax rebate is modelled in the tax brackets. The £50 cap on the rebate is not modelled.'}` |
+| `wff` | `{'source': 'Placeholder', 'notes': 'NEEDS RESEARCH. WFF did not exist. The rules for historical family assistance programs are unknown.'}` |
+| `ppl` | `{'source': 'Placeholder', 'notes': 'NEEDS RESEARCH. Paid Parental Leave scheme of 1962 is unknown.'}` |
+| `child_support` | `{'source': 'Placeholder', 'notes': 'NEEDS RESEARCH. Child support rules for 1962 is unknown.'}` |
+| `acc_levy` | `{'source': "Gemini Web Search, 2025-08-10, 'New Zealand income tax rates 1962'", 'notes': "This represents the 'Social Security Income Tax' of 7.5%. The first £104 of annual income was exempt from this tax, which is not modelled here. The name 'acc_levy' is used due to the current data structure. There was no income cap mentioned for this tax."}` |
+
+
+### `tax_brackets`
+
+| Parameter | Value |
+| --- | --- |
+| `rates` | `[0.1425, 0.72675]` |
+| `thresholds` | `[300]` |
+
+
+### `ietc`
+
+| Parameter | Value |
+| --- | --- |
+| `thrin` | `0` |
+| `ent` | `0` |
+| `thrab` | `0` |
+| `abrate` | `0` |
+
+
+### `wff`
+
+| Parameter | Value |
+| --- | --- |
+| `ftc1` | `0` |
+| `ftc2` | `0` |
+| `iwtc1` | `0` |
+| `iwtc2` | `0` |
+| `bstc` | `0` |
+| `mftc` | `0` |
+| `abatethresh1` | `0` |
+| `abatethresh2` | `0` |
+| `abaterate1` | `0` |
+| `abaterate2` | `0` |
+| `bstcthresh` | `0` |
+| `bstcabate` | `0` |
+
+
+### `ppl`
+
+| Parameter | Value |
+| --- | --- |
+| `enabled` | `False` |
+| `weekly_rate` | `0` |
+| `max_weeks` | `0` |
+
+
+### `child_support`
+
+| Parameter | Value |
+| --- | --- |
+| `enabled` | `False` |
+| `support_rate` | `0` |
+
+
+### `acc_levy`
+
+| Parameter | Value |
+| --- | --- |
+| `rate` | `0.075` |
+| `max_income` | `999999` |
+
+
+## 1963-1964
+
+### `_source_references`
+
+| Parameter | Value |
+| --- | --- |
+| `tax_brackets` | `{'source': "Gemini Web Search, 2025-08-10, 'New Zealand income tax rates 1963'", 'reference_ids': [], 'notes': 'The values here are an approximation of the 1963 tax system. The rates are the 1954 rates with a 10% rebate applied. This rebate had a maximum cap, which is not modelled here. The top rate of 76.5% is from previous years and is assumed to be the maximum rate.'}` |
+| `ietc` | `{'source': 'Placeholder', 'notes': 'The 10% tax rebate is modelled in the tax brackets. The maximum cap on the rebate is not modelled.'}` |
+| `wff` | `{'source': 'Placeholder', 'notes': 'NEEDS RESEARCH. WFF did not exist. The rules for historical family assistance programs are unknown.'}` |
+| `ppl` | `{'source': 'Placeholder', 'notes': 'NEEDS RESEARCH. Paid Parental Leave scheme of 1963 is unknown.'}` |
+| `child_support` | `{'source': 'Placeholder', 'notes': 'NEEDS RESEARCH. Child support rules for 1963 is unknown.'}` |
+| `acc_levy` | `{'source': "Gemini Web Search, 2025-08-10, 'New Zealand income tax rates 1963'", 'notes': "This represents the 'Social Security Income Tax' of 7.5%. There was a low annual exemption from this tax, which is not modelled here. The name 'acc_levy' is used due to the current data structure. There was no income cap mentioned for this tax."}` |
+
+
+### `tax_brackets`
+
+| Parameter | Value |
+| --- | --- |
+| `rates` | `[0.135, 0.6885]` |
+| `thresholds` | `[300]` |
+
+
+### `ietc`
+
+| Parameter | Value |
+| --- | --- |
+| `thrin` | `0` |
+| `ent` | `0` |
+| `thrab` | `0` |
+| `abrate` | `0` |
+
+
+### `wff`
+
+| Parameter | Value |
+| --- | --- |
+| `ftc1` | `0` |
+| `ftc2` | `0` |
+| `iwtc1` | `0` |
+| `iwtc2` | `0` |
+| `bstc` | `0` |
+| `mftc` | `0` |
+| `abatethresh1` | `0` |
+| `abatethresh2` | `0` |
+| `abaterate1` | `0` |
+| `abaterate2` | `0` |
+| `bstcthresh` | `0` |
+| `bstcabate` | `0` |
+
+
+### `ppl`
+
+| Parameter | Value |
+| --- | --- |
+| `enabled` | `False` |
+| `weekly_rate` | `0` |
+| `max_weeks` | `0` |
+
+
+### `child_support`
+
+| Parameter | Value |
+| --- | --- |
+| `enabled` | `False` |
+| `support_rate` | `0` |
+
+
+### `acc_levy`
+
+| Parameter | Value |
+| --- | --- |
+| `rate` | `0.075` |
+| `max_income` | `999999` |
+
+
+## 1964-1965
+
+### `_source_references`
+
+| Parameter | Value |
+| --- | --- |
+| `tax_brackets` | `{'source': "Gemini Web Search, 2025-08-10, 'New Zealand income tax rates 1964'", 'reference_ids': [], 'notes': 'The values here are an approximation of the 1964 tax system. The rates are the 1954 rates with a 10% rebate applied. This rebate was capped at £100, which is not modelled here. The top rate of 76.5% is from previous years and is assumed to be the maximum rate.'}` |
+| `ietc` | `{'source': 'Placeholder', 'notes': 'The 10% tax rebate is modelled in the tax brackets. The £100 cap on the rebate is not modelled.'}` |
+| `wff` | `{'source': 'Placeholder', 'notes': 'NEEDS RESEARCH. WFF did not exist. The rules for historical family assistance programs are unknown.'}` |
+| `ppl` | `{'source': 'Placeholder', 'notes': 'NEEDS RESEARCH. Paid Parental Leave scheme of 1964 is unknown.'}` |
+| `child_support` | `{'source': 'Placeholder', 'notes': 'NEEDS RESEARCH. Child support rules for 1964 is unknown.'}` |
+| `acc_levy` | `{'source': "Gemini Web Search, 2025-08-10, 'New Zealand income tax rates 1963'", 'notes': "This represents the 'Social Security Income Tax' of 7.5%. There was a low annual exemption from this tax, which is not modelled here. The name 'acc_levy' is used due to the current data structure. There was no income cap mentioned for this tax."}` |
+
+
+### `tax_brackets`
+
+| Parameter | Value |
+| --- | --- |
+| `rates` | `[0.135, 0.6885]` |
+| `thresholds` | `[300]` |
+
+
+### `ietc`
+
+| Parameter | Value |
+| --- | --- |
+| `thrin` | `0` |
+| `ent` | `0` |
+| `thrab` | `0` |
+| `abrate` | `0` |
+
+
+### `wff`
+
+| Parameter | Value |
+| --- | --- |
+| `ftc1` | `0` |
+| `ftc2` | `0` |
+| `iwtc1` | `0` |
+| `iwtc2` | `0` |
+| `bstc` | `0` |
+| `mftc` | `0` |
+| `abatethresh1` | `0` |
+| `abatethresh2` | `0` |
+| `abaterate1` | `0` |
+| `abaterate2` | `0` |
+| `bstcthresh` | `0` |
+| `bstcabate` | `0` |
+
+
+### `ppl`
+
+| Parameter | Value |
+| --- | --- |
+| `enabled` | `False` |
+| `weekly_rate` | `0` |
+| `max_weeks` | `0` |
+
+
+### `child_support`
+
+| Parameter | Value |
+| --- | --- |
+| `enabled` | `False` |
+| `support_rate` | `0` |
+
+
+### `acc_levy`
+
+| Parameter | Value |
+| --- | --- |
+| `rate` | `0.075` |
+| `max_income` | `999999` |
+
+
+## 1965-1966
+
+### `_source_references`
+
+| Parameter | Value |
+| --- | --- |
+| `tax_brackets` | `{'source': 'nz_personal_tax_rules.json: year 1965 entry', 'reference_ids': ['152018581057803-L19-L21'], 'notes': 'NEEDS RESEARCH. Source only provides the top marginal tax rate of 68%. The full bracket structure is unknown. The values here are placeholders and do not represent a valid tax system.'}` |
+| `ietc` | `{'source': 'Placeholder', 'notes': 'NEEDS RESEARCH. The structure of low-income tax relief in 1965 is unknown.'}` |
+| `wff` | `{'source': 'Placeholder', 'notes': 'NEEDS RESEARCH. WFF did not exist. The rules for historical family assistance programs are unknown.'}` |
+| `ppl` | `{'source': 'Placeholder', 'notes': 'NEEDS RESEARCH. Paid Parental Leave scheme of 1965 is unknown.'}` |
+| `child_support` | `{'source': 'Placeholder', 'notes': 'NEEDS RESEARCH. Child support rules for 1965 is unknown.'}` |
+| `acc_levy` | `{'source': 'Placeholder', 'notes': 'NEEDS RESEARCH. The ACC levy rate and income cap for 1965 are unknown.'}` |
+
+
+### `tax_brackets`
+
+| Parameter | Value |
+| --- | --- |
+| `rates` | `[0.68]` |
+| `thresholds` | `[]` |
+
+
+### `ietc`
+
+| Parameter | Value |
+| --- | --- |
+| `thrin` | `0` |
+| `ent` | `0` |
+| `thrab` | `0` |
+| `abrate` | `0` |
+
+
+### `wff`
+
+| Parameter | Value |
+| --- | --- |
+| `ftc1` | `0` |
+| `ftc2` | `0` |
+| `iwtc1` | `0` |
+| `iwtc2` | `0` |
+| `bstc` | `0` |
+| `mftc` | `0` |
+| `abatethresh1` | `0` |
+| `abatethresh2` | `0` |
+| `abaterate1` | `0` |
+| `abaterate2` | `0` |
+| `bstcthresh` | `0` |
+| `bstcabate` | `0` |
+
+
+### `ppl`
+
+| Parameter | Value |
+| --- | --- |
+| `enabled` | `False` |
+| `weekly_rate` | `0` |
+| `max_weeks` | `0` |
+
+
+### `child_support`
+
+| Parameter | Value |
+| --- | --- |
+| `enabled` | `False` |
+| `support_rate` | `0` |
+
+
+### `acc_levy`
+
+| Parameter | Value |
+| --- | --- |
+| `rate` | `0.0` |
+| `max_income` | `0` |
+
+
+## 1966-1967
+
+### `_source_references`
+
+| Parameter | Value |
+| --- | --- |
+| `tax_brackets` | `{'source': "Gemini Web Search, 2025-08-10, 'New Zealand income tax rates 1966'", 'reference_ids': [], 'notes': 'The values here are an approximation of the 1966 tax system. The rates are the 1965 rates with a 10% rebate applied. This rebate was capped at £100, which is not modelled here. The top rate of 68% is from the 1965 placeholder file and is assumed to be the maximum rate.'}` |
+| `ietc` | `{'source': 'Placeholder', 'notes': 'The 10% tax rebate is modelled in the tax brackets. The £100 cap on the rebate is not modelled.'}` |
+| `wff` | `{'source': 'Placeholder', 'notes': 'NEEDS RESEARCH. WFF did not exist. The rules for historical family assistance programs are unknown.'}` |
+| `ppl` | `{'source': 'Placeholder', 'notes': 'NEEDS RESEARCH. Paid Parental Leave scheme of 1966 is unknown.'}` |
+| `child_support` | `{'source': 'Placeholder', 'notes': 'NEEDS RESEARCH. Child support rules for 1966 is unknown.'}` |
+| `acc_levy` | `{'source': "Gemini Web Search, 2025-08-10, 'New Zealand income tax rates 1966'", 'notes': "This represents the 'Social Security Income Tax' of 7.5%. The first £104 of annual income was exempt from this tax, which is not modelled here. The name 'acc_levy' is used due to the current data structure. There was no income cap mentioned for this tax."}` |
+
+
+### `tax_brackets`
+
+| Parameter | Value |
+| --- | --- |
+| `rates` | `[0.135, 0.612]` |
+| `thresholds` | `[300]` |
+
+
+### `ietc`
+
+| Parameter | Value |
+| --- | --- |
+| `thrin` | `0` |
+| `ent` | `0` |
+| `thrab` | `0` |
+| `abrate` | `0` |
+
+
+### `wff`
+
+| Parameter | Value |
+| --- | --- |
+| `ftc1` | `0` |
+| `ftc2` | `0` |
+| `iwtc1` | `0` |
+| `iwtc2` | `0` |
+| `bstc` | `0` |
+| `mftc` | `0` |
+| `abatethresh1` | `0` |
+| `abatethresh2` | `0` |
+| `abaterate1` | `0` |
+| `abaterate2` | `0` |
+| `bstcthresh` | `0` |
+| `bstcabate` | `0` |
+
+
+### `ppl`
+
+| Parameter | Value |
+| --- | --- |
+| `enabled` | `False` |
+| `weekly_rate` | `0` |
+| `max_weeks` | `0` |
+
+
+### `child_support`
+
+| Parameter | Value |
+| --- | --- |
+| `enabled` | `False` |
+| `support_rate` | `0` |
+
+
+### `acc_levy`
+
+| Parameter | Value |
+| --- | --- |
+| `rate` | `0.075` |
+| `max_income` | `999999` |
+
+
+## 1967-1968
+
+### `_source_references`
+
+| Parameter | Value |
+| --- | --- |
+| `tax_brackets` | `{'source': "Gemini Web Search, 2025-08-10, 'New Zealand income tax rates 1967'", 'reference_ids': [], 'notes': 'The values here are an approximation of the 1967 tax system. The rates are the 1966 rates with a 10% rebate applied. This rebate was capped at $200, which is not modelled here. The top rate of 68% is from previous years and is assumed to be the maximum rate. The currency was decimalized in 1967, and the threshold is an assumption in dollars.'}` |
+| `ietc` | `{'source': 'Placeholder', 'notes': 'The 10% tax rebate is modelled in the tax brackets. The $200 cap on the rebate is not modelled.'}` |
+| `wff` | `{'source': 'Placeholder', 'notes': 'NEEDS RESEARCH. WFF did not exist. The rules for historical family assistance programs are unknown.'}` |
+| `ppl` | `{'source': 'Placeholder', 'notes': 'NEEDS RESEARCH. Paid Parental Leave scheme of 1967 is unknown.'}` |
+| `child_support` | `{'source': 'Placeholder', 'notes': 'NEEDS RESEARCH. Child support rules for 1967 is unknown.'}` |
+| `acc_levy` | `{'source': "Gemini Web Search, 2025-08-10, 'New Zealand income tax rates 1967'", 'notes': "This represents the 'Social Security Income Tax' of 7.5%. The first $208 of annual income (£104) was exempt from this tax, which is not modelled here. The name 'acc_levy' is used due to the current data structure. There was no income cap mentioned for this tax."}` |
+
+
+### `tax_brackets`
+
+| Parameter | Value |
+| --- | --- |
+| `rates` | `[0.135, 0.612]` |
+| `thresholds` | `[600]` |
+
+
+### `ietc`
+
+| Parameter | Value |
+| --- | --- |
+| `thrin` | `0` |
+| `ent` | `0` |
+| `thrab` | `0` |
+| `abrate` | `0` |
+
+
+### `wff`
+
+| Parameter | Value |
+| --- | --- |
+| `ftc1` | `0` |
+| `ftc2` | `0` |
+| `iwtc1` | `0` |
+| `iwtc2` | `0` |
+| `bstc` | `0` |
+| `mftc` | `0` |
+| `abatethresh1` | `0` |
+| `abatethresh2` | `0` |
+| `abaterate1` | `0` |
+| `abaterate2` | `0` |
+| `bstcthresh` | `0` |
+| `bstcabate` | `0` |
+
+
+### `ppl`
+
+| Parameter | Value |
+| --- | --- |
+| `enabled` | `False` |
+| `weekly_rate` | `0` |
+| `max_weeks` | `0` |
+
+
+### `child_support`
+
+| Parameter | Value |
+| --- | --- |
+| `enabled` | `False` |
+| `support_rate` | `0` |
+
+
+### `acc_levy`
+
+| Parameter | Value |
+| --- | --- |
+| `rate` | `0.075` |
+| `max_income` | `999999` |
+
+
+## 1968-1969
+
+### `_source_references`
+
+| Parameter | Value |
+| --- | --- |
+| `tax_brackets` | `{'source': "Gemini Web Search, 2025-08-10, 'New Zealand income tax rates 1968'", 'reference_ids': [], 'notes': 'The values here are an approximation of the 1968 tax system. The rates are the 1965 rates with a 10% rebate applied. This rebate was capped at $200, which is not modelled here. The top rate of 68% is from previous years and is assumed to be the maximum rate.'}` |
+| `ietc` | `{'source': 'Placeholder', 'notes': 'The 10% tax rebate is modelled in the tax brackets. The $200 cap on the rebate is not modelled.'}` |
+| `wff` | `{'source': 'Placeholder', 'notes': 'NEEDS RESEARCH. WFF did not exist. The rules for historical family assistance programs are unknown.'}` |
+| `ppl` | `{'source': 'Placeholder', 'notes': 'NEEDS RESEARCH. Paid Parental Leave scheme of 1968 is unknown.'}` |
+| `child_support` | `{'source': 'Placeholder', 'notes': 'NEEDS RESEARCH. Child support rules for 1968 is unknown.'}` |
+| `acc_levy` | `{'source': "Gemini Web Search, 2025-08-10, 'New Zealand income tax rates 1968'", 'notes': "This represents the 'Social Security Income Tax' of 7.5%. There was a low annual exemption from this tax, which is not modelled here. The name 'acc_levy' is used due to the current data structure. There was no income cap mentioned for this tax."}` |
+
+
+### `tax_brackets`
+
+| Parameter | Value |
+| --- | --- |
+| `rates` | `[0.135, 0.612]` |
+| `thresholds` | `[600]` |
+
+
+### `ietc`
+
+| Parameter | Value |
+| --- | --- |
+| `thrin` | `0` |
+| `ent` | `0` |
+| `thrab` | `0` |
+| `abrate` | `0` |
+
+
+### `wff`
+
+| Parameter | Value |
+| --- | --- |
+| `ftc1` | `0` |
+| `ftc2` | `0` |
+| `iwtc1` | `0` |
+| `iwtc2` | `0` |
+| `bstc` | `0` |
+| `mftc` | `0` |
+| `abatethresh1` | `0` |
+| `abatethresh2` | `0` |
+| `abaterate1` | `0` |
+| `abaterate2` | `0` |
+| `bstcthresh` | `0` |
+| `bstcabate` | `0` |
+
+
+### `ppl`
+
+| Parameter | Value |
+| --- | --- |
+| `enabled` | `False` |
+| `weekly_rate` | `0` |
+| `max_weeks` | `0` |
+
+
+### `child_support`
+
+| Parameter | Value |
+| --- | --- |
+| `enabled` | `False` |
+| `support_rate` | `0` |
+
+
+### `acc_levy`
+
+| Parameter | Value |
+| --- | --- |
+| `rate` | `0.075` |
+| `max_income` | `999999` |
+
+
+## 1969-1970
+
+### `_source_references`
+
+| Parameter | Value |
+| --- | --- |
+| `tax_brackets` | `{'source': "Gemini Web Search, 2025-08-10, 'New Zealand income tax rates 1969'", 'reference_ids': [], 'notes': 'NEEDS RESEARCH. The full bracket structure is unknown. The values here are an approximation of the 1969 tax system, which merged the ordinary income tax and the Social Security Income Tax. The previous 7.5% SSIT has been incorporated into the bracket structure. The top rate of 68% is from previous years and is assumed to be the maximum rate.'}` |
+| `ietc` | `{'source': 'Placeholder', 'notes': 'NEEDS RESEARCH. The structure of low-income tax relief in 1969 is unknown.'}` |
+| `wff` | `{'source': 'Placeholder', 'notes': 'NEEDS RESEARCH. WFF did not exist. The rules for historical family assistance programs are unknown.'}` |
+| `ppl` | `{'source': 'Placeholder', 'notes': 'NEEDS RESEARCH. Paid Parental Leave scheme of 1969 is unknown.'}` |
+| `child_support` | `{'source': 'Placeholder', 'notes': 'NEEDS RESEARCH. Child support rules for 1969 is unknown.'}` |
+| `acc_levy` | `{'source': "Gemini Web Search, 2025-08-10, 'New Zealand income tax rates 1969'", 'notes': 'The Social Security Income Tax was merged with the ordinary income tax in 1969. Therefore, the rate is set to 0.'}` |
+
+
+### `tax_brackets`
+
+| Parameter | Value |
+| --- | --- |
+| `rates` | `[0.225, 0.68]` |
+| `thresholds` | `[600]` |
+
+
+### `ietc`
+
+| Parameter | Value |
+| --- | --- |
+| `thrin` | `0` |
+| `ent` | `0` |
+| `thrab` | `0` |
+| `abrate` | `0` |
+
+
+### `wff`
+
+| Parameter | Value |
+| --- | --- |
+| `ftc1` | `0` |
+| `ftc2` | `0` |
+| `iwtc1` | `0` |
+| `iwtc2` | `0` |
+| `bstc` | `0` |
+| `mftc` | `0` |
+| `abatethresh1` | `0` |
+| `abatethresh2` | `0` |
+| `abaterate1` | `0` |
+| `abaterate2` | `0` |
+| `bstcthresh` | `0` |
+| `bstcabate` | `0` |
+
+
+### `ppl`
+
+| Parameter | Value |
+| --- | --- |
+| `enabled` | `False` |
+| `weekly_rate` | `0` |
+| `max_weeks` | `0` |
+
+
+### `child_support`
+
+| Parameter | Value |
+| --- | --- |
+| `enabled` | `False` |
+| `support_rate` | `0` |
+
+
+### `acc_levy`
+
+| Parameter | Value |
+| --- | --- |
+| `rate` | `0.0` |
+| `max_income` | `0` |
+
+
+## 1970-1971
+
+### `_source_references`
+
+| Parameter | Value |
+| --- | --- |
+| `tax_brackets` | `{'source': 'nz_personal_tax_rules.json: year 1970 entry', 'reference_ids': ['152018581057803-L21-L22'], 'notes': 'NEEDS RESEARCH. Source only provides the top marginal tax rate of 68%. The full bracket structure is unknown. The values here are placeholders and do not represent a valid tax system.'}` |
+| `ietc` | `{'source': 'Placeholder', 'notes': 'NEEDS RESEARCH. The structure of low-income tax relief in 1970 is unknown.'}` |
+| `wff` | `{'source': 'Placeholder', 'notes': 'NEEDS RESEARCH. WFF did not exist. The rules for historical family assistance programs are unknown.'}` |
+| `ppl` | `{'source': 'Placeholder', 'notes': 'NEEDS RESEARCH. Paid Parental Leave scheme of 1970 is unknown.'}` |
+| `child_support` | `{'source': 'Placeholder', 'notes': 'NEEDS RESEARCH. Child support rules for 1970 is unknown.'}` |
+| `acc_levy` | `{'source': 'Placeholder', 'notes': 'NEEDS RESEARCH. The ACC levy rate and income cap for 1970 are unknown.'}` |
+
+
+### `tax_brackets`
+
+| Parameter | Value |
+| --- | --- |
+| `rates` | `[0.68]` |
+| `thresholds` | `[]` |
+
+
+### `ietc`
+
+| Parameter | Value |
+| --- | --- |
+| `thrin` | `0` |
+| `ent` | `0` |
+| `thrab` | `0` |
+| `abrate` | `0` |
+
+
+### `wff`
+
+| Parameter | Value |
+| --- | --- |
+| `ftc1` | `0` |
+| `ftc2` | `0` |
+| `iwtc1` | `0` |
+| `iwtc2` | `0` |
+| `bstc` | `0` |
+| `mftc` | `0` |
+| `abatethresh1` | `0` |
+| `abatethresh2` | `0` |
+| `abaterate1` | `0` |
+| `abaterate2` | `0` |
+| `bstcthresh` | `0` |
+| `bstcabate` | `0` |
+
+
+### `ppl`
+
+| Parameter | Value |
+| --- | --- |
+| `enabled` | `False` |
+| `weekly_rate` | `0` |
+| `max_weeks` | `0` |
+
+
+### `child_support`
+
+| Parameter | Value |
+| --- | --- |
+| `enabled` | `False` |
+| `support_rate` | `0` |
+
+
+### `acc_levy`
+
+| Parameter | Value |
+| --- | --- |
+| `rate` | `0.0` |
+| `max_income` | `0` |
+
+
+## 1971-1972
+
+### `_source_references`
+
+| Parameter | Value |
+| --- | --- |
+| `tax_brackets` | `{'source': 'nz_personal_tax_rules.json: year 1971 entry', 'reference_ids': ['152018581057803-L21-L22'], 'notes': 'NEEDS RESEARCH. Source only provides the top marginal tax rate of 68%. The full bracket structure is unknown. The values here are placeholders and do not represent a valid tax system.'}` |
+| `ietc` | `{'source': 'Placeholder', 'notes': 'NEEDS RESEARCH. The structure of low-income tax relief in 1971 is unknown.'}` |
+| `wff` | `{'source': 'Placeholder', 'notes': 'NEEDS RESEARCH. WFF did not exist. The rules for historical family assistance programs are unknown.'}` |
+| `ppl` | `{'source': 'Placeholder', 'notes': 'NEEDS RESEARCH. Paid Parental Leave scheme of 1971 is unknown.'}` |
+| `child_support` | `{'source': 'Placeholder', 'notes': 'NEEDS RESEARCH. Child support rules for 1971 is unknown.'}` |
+| `acc_levy` | `{'source': 'Placeholder', 'notes': 'NEEDS RESEARCH. The ACC levy rate and income cap for 1971 are unknown.'}` |
+
+
+### `tax_brackets`
+
+| Parameter | Value |
+| --- | --- |
+| `rates` | `[0.68]` |
+| `thresholds` | `[]` |
+
+
+### `ietc`
+
+| Parameter | Value |
+| --- | --- |
+| `thrin` | `0` |
+| `ent` | `0` |
+| `thrab` | `0` |
+| `abrate` | `0` |
+
+
+### `wff`
+
+| Parameter | Value |
+| --- | --- |
+| `ftc1` | `0` |
+| `ftc2` | `0` |
+| `iwtc1` | `0` |
+| `iwtc2` | `0` |
+| `bstc` | `0` |
+| `mftc` | `0` |
+| `abatethresh1` | `0` |
+| `abatethresh2` | `0` |
+| `abaterate1` | `0` |
+| `abaterate2` | `0` |
+| `bstcthresh` | `0` |
+| `bstcabate` | `0` |
+
+
+### `ppl`
+
+| Parameter | Value |
+| --- | --- |
+| `enabled` | `False` |
+| `weekly_rate` | `0` |
+| `max_weeks` | `0` |
+
+
+### `child_support`
+
+| Parameter | Value |
+| --- | --- |
+| `enabled` | `False` |
+| `support_rate` | `0` |
+
+
+### `acc_levy`
+
+| Parameter | Value |
+| --- | --- |
+| `rate` | `0.0` |
+| `max_income` | `0` |
+
+
+## 1972-1973
+
+### `_source_references`
+
+| Parameter | Value |
+| --- | --- |
+| `tax_brackets` | `{'source': 'Placeholder based on 1971-1972 data.', 'reference_ids': [], 'notes': 'NEEDS RESEARCH. The full bracket structure is unknown. The Land and Income Tax Amendment Act (No. 2) 1972 introduced a 7.5% rebate on personal income tax, but the underlying bracket structure is not readily available. The values here are placeholders and do not represent a valid tax system.'}` |
+| `ietc` | `{'source': 'Placeholder', 'notes': 'NEEDS RESEARCH. The structure of low-income tax relief in 1972 is unknown.'}` |
+| `wff` | `{'source': 'Placeholder', 'notes': 'NEEDS RESEARCH. WFF did not exist. The rules for historical family assistance programs are unknown.'}` |
+| `ppl` | `{'source': 'Placeholder', 'notes': 'NEEDS RESEARCH. Paid Parental Leave scheme of 1972 is unknown.'}` |
+| `child_support` | `{'source': 'Placeholder', 'notes': 'NEEDS RESEARCH. Child support rules for 1972 is unknown.'}` |
+| `acc_levy` | `{'source': 'Placeholder', 'notes': 'NEEDS RESEARCH. The ACC levy rate and income cap for 1972 are unknown.'}` |
+
+
+### `tax_brackets`
+
+| Parameter | Value |
+| --- | --- |
+| `rates` | `[0.68]` |
+| `thresholds` | `[]` |
+
+
+### `ietc`
+
+| Parameter | Value |
+| --- | --- |
+| `thrin` | `0` |
+| `ent` | `0` |
+| `thrab` | `0` |
+| `abrate` | `0` |
+
+
+### `wff`
+
+| Parameter | Value |
+| --- | --- |
+| `ftc1` | `0` |
+| `ftc2` | `0` |
+| `iwtc1` | `0` |
+| `iwtc2` | `0` |
+| `bstc` | `0` |
+| `mftc` | `0` |
+| `abatethresh1` | `0` |
+| `abatethresh2` | `0` |
+| `abaterate1` | `0` |
+| `abaterate2` | `0` |
+| `bstcthresh` | `0` |
+| `bstcabate` | `0` |
+
+
+### `ppl`
+
+| Parameter | Value |
+| --- | --- |
+| `enabled` | `False` |
+| `weekly_rate` | `0` |
+| `max_weeks` | `0` |
+
+
+### `child_support`
+
+| Parameter | Value |
+| --- | --- |
+| `enabled` | `False` |
+| `support_rate` | `0` |
+
+
+### `acc_levy`
+
+| Parameter | Value |
+| --- | --- |
+| `rate` | `0.0` |
+| `max_income` | `0` |
+
+
+## 1973-1974
+
+### `_source_references`
+
+| Parameter | Value |
+| --- | --- |
+| `tax_brackets` | `{'source': 'Placeholder based on 1971-1972 data.', 'reference_ids': [], 'notes': 'NEEDS RESEARCH. The full bracket structure is unknown. The Land and Income Tax Amendment Act (No. 2) 1972 introduced a 7.5% rebate on personal income tax, but the underlying bracket structure is not readily available. The values here are placeholders and do not represent a valid tax system.'}` |
+| `ietc` | `{'source': 'Placeholder', 'notes': 'NEEDS RESEARCH. The structure of low-income tax relief in 1972 is unknown.'}` |
+| `wff` | `{'source': 'Placeholder', 'notes': 'NEEDS RESEARCH. WFF did not exist. The rules for historical family assistance programs are unknown.'}` |
+| `ppl` | `{'source': 'Placeholder', 'notes': 'NEEDS RESEARCH. Paid Parental Leave scheme of 1972 is unknown.'}` |
+| `child_support` | `{'source': 'Placeholder', 'notes': 'NEEDS RESEARCH. Child support rules for 1972 is unknown.'}` |
+| `acc_levy` | `{'source': 'Placeholder', 'notes': 'NEEDS RESEARCH. The ACC levy rate and income cap for 1972 are unknown.'}` |
+
+
+### `tax_brackets`
+
+| Parameter | Value |
+| --- | --- |
+| `rates` | `[0.68]` |
+| `thresholds` | `[]` |
+
+
+### `ietc`
+
+| Parameter | Value |
+| --- | --- |
+| `thrin` | `0` |
+| `ent` | `0` |
+| `thrab` | `0` |
+| `abrate` | `0` |
+
+
+### `wff`
+
+| Parameter | Value |
+| --- | --- |
+| `ftc1` | `0` |
+| `ftc2` | `0` |
+| `iwtc1` | `0` |
+| `iwtc2` | `0` |
+| `bstc` | `0` |
+| `mftc` | `0` |
+| `abatethresh1` | `0` |
+| `abatethresh2` | `0` |
+| `abaterate1` | `0` |
+| `abaterate2` | `0` |
+| `bstcthresh` | `0` |
+| `bstcabate` | `0` |
+
+
+### `ppl`
+
+| Parameter | Value |
+| --- | --- |
+| `enabled` | `False` |
+| `weekly_rate` | `0` |
+| `max_weeks` | `0` |
+
+
+### `child_support`
+
+| Parameter | Value |
+| --- | --- |
+| `enabled` | `False` |
+| `support_rate` | `0` |
+
+
+### `acc_levy`
+
+| Parameter | Value |
+| --- | --- |
+| `rate` | `0.0` |
+| `max_income` | `0` |
+
+
+## 1974-1975
+
+### `_source_references`
+
+| Parameter | Value |
+| --- | --- |
+| `tax_brackets` | `{'source': 'Placeholder based on 1971-1972 data.', 'reference_ids': [], 'notes': 'NEEDS RESEARCH. The full bracket structure is unknown. The Land and Income Tax Amendment Act (No. 2) 1972 introduced a 7.5% rebate on personal income tax, but the underlying bracket structure is not readily available. The values here are placeholders and do not represent a valid tax system.'}` |
+| `ietc` | `{'source': 'Placeholder', 'notes': 'NEEDS RESEARCH. The structure of low-income tax relief in 1972 is unknown.'}` |
+| `wff` | `{'source': 'Placeholder', 'notes': 'NEEDS RESEARCH. WFF did not exist. The rules for historical family assistance programs are unknown.'}` |
+| `ppl` | `{'source': 'Placeholder', 'notes': 'NEEDS RESEARCH. Paid Parental Leave scheme of 1972 is unknown.'}` |
+| `child_support` | `{'source': 'Placeholder', 'notes': 'NEEDS RESEARCH. Child support rules for 1972 is unknown.'}` |
+| `acc_levy` | `{'source': 'Placeholder', 'notes': 'NEEDS RESEARCH. The ACC levy rate and income cap for 1972 are unknown.'}` |
+
+
+### `tax_brackets`
+
+| Parameter | Value |
+| --- | --- |
+| `rates` | `[0.68]` |
+| `thresholds` | `[]` |
+
+
+### `ietc`
+
+| Parameter | Value |
+| --- | --- |
+| `thrin` | `0` |
+| `ent` | `0` |
+| `thrab` | `0` |
+| `abrate` | `0` |
+
+
+### `wff`
+
+| Parameter | Value |
+| --- | --- |
+| `ftc1` | `0` |
+| `ftc2` | `0` |
+| `iwtc1` | `0` |
+| `iwtc2` | `0` |
+| `bstc` | `0` |
+| `mftc` | `0` |
+| `abatethresh1` | `0` |
+| `abatethresh2` | `0` |
+| `abaterate1` | `0` |
+| `abaterate2` | `0` |
+| `bstcthresh` | `0` |
+| `bstcabate` | `0` |
+
+
+### `ppl`
+
+| Parameter | Value |
+| --- | --- |
+| `enabled` | `False` |
+| `weekly_rate` | `0` |
+| `max_weeks` | `0` |
+
+
+### `child_support`
+
+| Parameter | Value |
+| --- | --- |
+| `enabled` | `False` |
+| `support_rate` | `0` |
+
+
+### `acc_levy`
+
+| Parameter | Value |
+| --- | --- |
+| `rate` | `0.0` |
+| `max_income` | `0` |
+
+
+## 1975-1976
+
+### `_source_references`
+
+| Parameter | Value |
+| --- | --- |
+| `tax_brackets` | `{'source': 'nz_personal_tax_rules.json: year 1975 entry', 'reference_ids': ['152018581057803-L22-L23'], 'notes': 'NEEDS RESEARCH. Source only provides the top marginal tax rate of 50%. The full bracket structure is unknown. The values here are placeholders and do not represent a valid tax system.'}` |
+| `ietc` | `{'source': 'Placeholder', 'notes': 'NEEDS RESEARCH. The structure of low-income tax relief in 1975 is unknown.'}` |
+| `wff` | `{'source': 'Placeholder', 'notes': 'NEEDS RESEARCH. WFF did not exist. The rules for historical family assistance programs are unknown.'}` |
+| `ppl` | `{'source': 'Placeholder', 'notes': 'NEEDS RESEARCH. Paid Parental Leave scheme of 1975 is unknown.'}` |
+| `child_support` | `{'source': 'Placeholder', 'notes': 'NEEDS RESEARCH. Child support rules for 1975 is unknown.'}` |
+| `acc_levy` | `{'source': 'Placeholder', 'notes': 'NEEDS RESEARCH. The ACC levy rate and income cap for 1975 are unknown.'}` |
+
+
+### `tax_brackets`
+
+| Parameter | Value |
+| --- | --- |
+| `rates` | `[0.5]` |
+| `thresholds` | `[]` |
+
+
+### `ietc`
+
+| Parameter | Value |
+| --- | --- |
+| `thrin` | `0` |
+| `ent` | `0` |
+| `thrab` | `0` |
+| `abrate` | `0` |
+
+
+### `wff`
+
+| Parameter | Value |
+| --- | --- |
+| `ftc1` | `0` |
+| `ftc2` | `0` |
+| `iwtc1` | `0` |
+| `iwtc2` | `0` |
+| `bstc` | `0` |
+| `mftc` | `0` |
+| `abatethresh1` | `0` |
+| `abatethresh2` | `0` |
+| `abaterate1` | `0` |
+| `abaterate2` | `0` |
+| `bstcthresh` | `0` |
+| `bstcabate` | `0` |
+
+
+### `ppl`
+
+| Parameter | Value |
+| --- | --- |
+| `enabled` | `False` |
+| `weekly_rate` | `0` |
+| `max_weeks` | `0` |
+
+
+### `child_support`
+
+| Parameter | Value |
+| --- | --- |
+| `enabled` | `False` |
+| `support_rate` | `0` |
+
+
+### `acc_levy`
+
+| Parameter | Value |
+| --- | --- |
+| `rate` | `0.0` |
+| `max_income` | `0` |
+
+
+## 1976-1977
+
+### `_source_references`
+
+| Parameter | Value |
+| --- | --- |
+| `tax_brackets` | `{'source': 'Placeholder based on 1975-1976 data.', 'reference_ids': [], 'notes': 'NEEDS RESEARCH. The full bracket structure is unknown. The values here are placeholders and do not represent a valid tax system.'}` |
+| `ietc` | `{'source': 'Placeholder', 'notes': 'NEEDS RESEARCH. The structure of low-income tax relief in 1976 is unknown.'}` |
+| `wff` | `{'source': 'Placeholder', 'notes': 'NEEDS RESEARCH. WFF did not exist. The rules for historical family assistance programs are unknown.'}` |
+| `ppl` | `{'source': 'Placeholder', 'notes': 'NEEDS RESEARCH. Paid Parental Leave scheme of 1976 is unknown.'}` |
+| `child_support` | `{'source': 'Placeholder', 'notes': 'NEEDS RESEARCH. Child support rules for 1976 is unknown.'}` |
+| `acc_levy` | `{'source': 'Placeholder', 'notes': 'NEEDS RESEARCH. The ACC levy rate and income cap for 1976 are unknown.'}` |
+
+
+### `tax_brackets`
+
+| Parameter | Value |
+| --- | --- |
+| `rates` | `[0.5]` |
+| `thresholds` | `[]` |
+
+
+### `ietc`
+
+| Parameter | Value |
+| --- | --- |
+| `thrin` | `0` |
+| `ent` | `0` |
+| `thrab` | `0` |
+| `abrate` | `0` |
+
+
+### `wff`
+
+| Parameter | Value |
+| --- | --- |
+| `ftc1` | `0` |
+| `ftc2` | `0` |
+| `iwtc1` | `0` |
+| `iwtc2` | `0` |
+| `bstc` | `0` |
+| `mftc` | `0` |
+| `abatethresh1` | `0` |
+| `abatethresh2` | `0` |
+| `abaterate1` | `0` |
+| `abaterate2` | `0` |
+| `bstcthresh` | `0` |
+| `bstcabate` | `0` |
+
+
+### `ppl`
+
+| Parameter | Value |
+| --- | --- |
+| `enabled` | `False` |
+| `weekly_rate` | `0` |
+| `max_weeks` | `0` |
+
+
+### `child_support`
+
+| Parameter | Value |
+| --- | --- |
+| `enabled` | `False` |
+| `support_rate` | `0` |
+
+
+### `acc_levy`
+
+| Parameter | Value |
+| --- | --- |
+| `rate` | `0.0` |
+| `max_income` | `0` |
+
+
+## 1977-1978
+
+### `_source_references`
+
+| Parameter | Value |
+| --- | --- |
+| `tax_brackets` | `{'source': 'Placeholder based on 1975-1976 data.', 'reference_ids': [], 'notes': 'NEEDS RESEARCH. The full bracket structure is unknown. The values here are placeholders and do not represent a valid tax system.'}` |
+| `ietc` | `{'source': 'Placeholder', 'notes': 'NEEDS RESEARCH. The structure of low-income tax relief in 1977 is unknown.'}` |
+| `wff` | `{'source': 'Placeholder', 'notes': 'NEEDS RESEARCH. WFF did not exist. The rules for historical family assistance programs are unknown.'}` |
+| `ppl` | `{'source': 'Placeholder', 'notes': 'NEEDS RESEARCH. Paid Parental Leave scheme of 1977 is unknown.'}` |
+| `child_support` | `{'source': 'Placeholder', 'notes': 'NEEDS RESEARCH. Child support rules for 1977 is unknown.'}` |
+| `acc_levy` | `{'source': 'Placeholder', 'notes': 'NEEDS RESEARCH. The ACC levy rate and income cap for 1977 are unknown.'}` |
+
+
+### `tax_brackets`
+
+| Parameter | Value |
+| --- | --- |
+| `rates` | `[0.5]` |
+| `thresholds` | `[]` |
+
+
+### `ietc`
+
+| Parameter | Value |
+| --- | --- |
+| `thrin` | `0` |
+| `ent` | `0` |
+| `thrab` | `0` |
+| `abrate` | `0` |
+
+
+### `wff`
+
+| Parameter | Value |
+| --- | --- |
+| `ftc1` | `0` |
+| `ftc2` | `0` |
+| `iwtc1` | `0` |
+| `iwtc2` | `0` |
+| `bstc` | `0` |
+| `mftc` | `0` |
+| `abatethresh1` | `0` |
+| `abatethresh2` | `0` |
+| `abaterate1` | `0` |
+| `abaterate2` | `0` |
+| `bstcthresh` | `0` |
+| `bstcabate` | `0` |
+
+
+### `ppl`
+
+| Parameter | Value |
+| --- | --- |
+| `enabled` | `False` |
+| `weekly_rate` | `0` |
+| `max_weeks` | `0` |
+
+
+### `child_support`
+
+| Parameter | Value |
+| --- | --- |
+| `enabled` | `False` |
+| `support_rate` | `0` |
+
+
+### `acc_levy`
+
+| Parameter | Value |
+| --- | --- |
+| `rate` | `0.0` |
+| `max_income` | `0` |
+
+
+## 1978-1979
+
+### `_source_references`
+
+| Parameter | Value |
+| --- | --- |
+| `tax_brackets` | `{'source': 'Placeholder based on 1975-1976 data.', 'reference_ids': [], 'notes': 'NEEDS RESEARCH. The full bracket structure is unknown. The values here are placeholders and do not represent a valid tax system.'}` |
+| `ietc` | `{'source': 'Placeholder', 'notes': 'NEEDS RESEARCH. The structure of low-income tax relief in 1978 is unknown.'}` |
+| `wff` | `{'source': 'Placeholder', 'notes': 'NEEDS RESEARCH. WFF did not exist. The rules for historical family assistance programs are unknown.'}` |
+| `ppl` | `{'source': 'Placeholder', 'notes': 'NEEDS RESEARCH. Paid Parental Leave scheme of 1978 is unknown.'}` |
+| `child_support` | `{'source': 'Placeholder', 'notes': 'NEEDS RESEARCH. Child support rules for 1978 is unknown.'}` |
+| `acc_levy` | `{'source': 'Placeholder', 'notes': 'NEEDS RESEARCH. The ACC levy rate and income cap for 1978 are unknown.'}` |
+
+
+### `tax_brackets`
+
+| Parameter | Value |
+| --- | --- |
+| `rates` | `[0.5]` |
+| `thresholds` | `[]` |
+
+
+### `ietc`
+
+| Parameter | Value |
+| --- | --- |
+| `thrin` | `0` |
+| `ent` | `0` |
+| `thrab` | `0` |
+| `abrate` | `0` |
+
+
+### `wff`
+
+| Parameter | Value |
+| --- | --- |
+| `ftc1` | `0` |
+| `ftc2` | `0` |
+| `iwtc1` | `0` |
+| `iwtc2` | `0` |
+| `bstc` | `0` |
+| `mftc` | `0` |
+| `abatethresh1` | `0` |
+| `abatethresh2` | `0` |
+| `abaterate1` | `0` |
+| `abaterate2` | `0` |
+| `bstcthresh` | `0` |
+| `bstcabate` | `0` |
+
+
+### `ppl`
+
+| Parameter | Value |
+| --- | --- |
+| `enabled` | `False` |
+| `weekly_rate` | `0` |
+| `max_weeks` | `0` |
+
+
+### `child_support`
+
+| Parameter | Value |
+| --- | --- |
+| `enabled` | `False` |
+| `support_rate` | `0` |
+
+
+### `acc_levy`
+
+| Parameter | Value |
+| --- | --- |
+| `rate` | `0.0` |
+| `max_income` | `0` |
+
+
+## 1979-1980
+
+### `_source_references`
+
+| Parameter | Value |
+| --- | --- |
+| `tax_brackets` | `{'source': 'Placeholder based on 1975-1976 data.', 'reference_ids': [], 'notes': 'NEEDS RESEARCH. The full bracket structure is unknown. The values here are placeholders and do not represent a valid tax system.'}` |
+| `ietc` | `{'source': 'Placeholder', 'notes': 'NEEDS RESEARCH. The structure of low-income tax relief in 1979 is unknown.'}` |
+| `wff` | `{'source': 'Placeholder', 'notes': 'NEEDS RESEARCH. WFF did not exist. The rules for historical family assistance programs are unknown.'}` |
+| `ppl` | `{'source': 'Placeholder', 'notes': 'NEEDS RESEARCH. Paid Parental Leave scheme of 1979 is unknown.'}` |
+| `child_support` | `{'source': 'Placeholder', 'notes': 'NEEDS RESEARCH. Child support rules for 1979 is unknown.'}` |
+| `acc_levy` | `{'source': 'Placeholder', 'notes': 'NEEDS RESEARCH. The ACC levy rate and income cap for 1979 are unknown.'}` |
+
+
+### `tax_brackets`
+
+| Parameter | Value |
+| --- | --- |
+| `rates` | `[0.5]` |
+| `thresholds` | `[]` |
+
+
+### `ietc`
+
+| Parameter | Value |
+| --- | --- |
+| `thrin` | `0` |
+| `ent` | `0` |
+| `thrab` | `0` |
+| `abrate` | `0` |
+
+
+### `wff`
+
+| Parameter | Value |
+| --- | --- |
+| `ftc1` | `0` |
+| `ftc2` | `0` |
+| `iwtc1` | `0` |
+| `iwtc2` | `0` |
+| `bstc` | `0` |
+| `mftc` | `0` |
+| `abatethresh1` | `0` |
+| `abatethresh2` | `0` |
+| `abaterate1` | `0` |
+| `abaterate2` | `0` |
+| `bstcthresh` | `0` |
+| `bstcabate` | `0` |
+
+
+### `ppl`
+
+| Parameter | Value |
+| --- | --- |
+| `enabled` | `False` |
+| `weekly_rate` | `0` |
+| `max_weeks` | `0` |
+
+
+### `child_support`
+
+| Parameter | Value |
+| --- | --- |
+| `enabled` | `False` |
+| `support_rate` | `0` |
+
+
+### `acc_levy`
+
+| Parameter | Value |
+| --- | --- |
+| `rate` | `0.0` |
+| `max_income` | `0` |
+
+
+## 1980-1981
+
+### `_source_references`
+
+| Parameter | Value |
+| --- | --- |
+| `tax_brackets` | `{'source': 'nz_personal_tax_rules.json: year 1980 entry', 'reference_ids': ['152018581057803-L23-L24'], 'notes': 'NEEDS RESEARCH. Source only provides the top marginal tax rate of 60%. The full bracket structure is unknown. The values here are placeholders and do not represent a valid tax system.'}` |
+| `ietc` | `{'source': 'Placeholder', 'notes': 'NEEDS RESEARCH. The structure of low-income tax relief in 1980 is unknown.'}` |
+| `wff` | `{'source': 'Placeholder', 'notes': 'NEEDS RESEARCH. WFF did not exist. The rules for historical family assistance programs are unknown.'}` |
+| `ppl` | `{'source': 'Placeholder', 'notes': 'NEEDS RESEARCH. Paid Parental Leave scheme of 1980 is unknown.'}` |
+| `child_support` | `{'source': 'Placeholder', 'notes': 'NEEDS RESEARCH. Child support rules for 1980 is unknown.'}` |
+| `acc_levy` | `{'source': 'Placeholder', 'notes': 'NEEDS RESEARCH. The ACC levy rate and income cap for 1980 are unknown.'}` |
+
+
+### `tax_brackets`
+
+| Parameter | Value |
+| --- | --- |
+| `rates` | `[0.6]` |
+| `thresholds` | `[]` |
+
+
+### `ietc`
+
+| Parameter | Value |
+| --- | --- |
+| `thrin` | `0` |
+| `ent` | `0` |
+| `thrab` | `0` |
+| `abrate` | `0` |
+
+
+### `wff`
+
+| Parameter | Value |
+| --- | --- |
+| `ftc1` | `0` |
+| `ftc2` | `0` |
+| `iwtc1` | `0` |
+| `iwtc2` | `0` |
+| `bstc` | `0` |
+| `mftc` | `0` |
+| `abatethresh1` | `0` |
+| `abatethresh2` | `0` |
+| `abaterate1` | `0` |
+| `abaterate2` | `0` |
+| `bstcthresh` | `0` |
+| `bstcabate` | `0` |
+
+
+### `ppl`
+
+| Parameter | Value |
+| --- | --- |
+| `enabled` | `False` |
+| `weekly_rate` | `0` |
+| `max_weeks` | `0` |
+
+
+### `child_support`
+
+| Parameter | Value |
+| --- | --- |
+| `enabled` | `False` |
+| `support_rate` | `0` |
+
+
+### `acc_levy`
+
+| Parameter | Value |
+| --- | --- |
+| `rate` | `0.0` |
+| `max_income` | `0` |
+
+
+## 1981-1982
+
+### `_source_references`
+
+| Parameter | Value |
+| --- | --- |
+| `tax_brackets` | `{'source': 'Placeholder based on 1980-1981 data.', 'reference_ids': [], 'notes': 'NEEDS RESEARCH. The full bracket structure is unknown. The values here are placeholders and do not represent a valid tax system.'}` |
+| `ietc` | `{'source': 'Placeholder', 'notes': 'NEEDS RESEARCH. The structure of low-income tax relief in 1981 is unknown.'}` |
+| `wff` | `{'source': 'Placeholder', 'notes': 'NEEDS RESEARCH. WFF did not exist. The rules for historical family assistance programs are unknown.'}` |
+| `ppl` | `{'source': 'Placeholder', 'notes': 'NEEDS RESEARCH. Paid Parental Leave scheme of 1981 is unknown.'}` |
+| `child_support` | `{'source': 'Placeholder', 'notes': 'NEEDS RESEARCH. Child support rules for 1981 is unknown.'}` |
+| `acc_levy` | `{'source': 'Placeholder', 'notes': 'NEEDS RESEARCH. The ACC levy rate and income cap for 1981 are unknown.'}` |
+
+
+### `tax_brackets`
+
+| Parameter | Value |
+| --- | --- |
+| `rates` | `[0.6]` |
+| `thresholds` | `[]` |
+
+
+### `ietc`
+
+| Parameter | Value |
+| --- | --- |
+| `thrin` | `0` |
+| `ent` | `0` |
+| `thrab` | `0` |
+| `abrate` | `0` |
+
+
+### `wff`
+
+| Parameter | Value |
+| --- | --- |
+| `ftc1` | `0` |
+| `ftc2` | `0` |
+| `iwtc1` | `0` |
+| `iwtc2` | `0` |
+| `bstc` | `0` |
+| `mftc` | `0` |
+| `abatethresh1` | `0` |
+| `abatethresh2` | `0` |
+| `abaterate1` | `0` |
+| `abaterate2` | `0` |
+| `bstcthresh` | `0` |
+| `bstcabate` | `0` |
+
+
+### `ppl`
+
+| Parameter | Value |
+| --- | --- |
+| `enabled` | `False` |
+| `weekly_rate` | `0` |
+| `max_weeks` | `0` |
+
+
+### `child_support`
+
+| Parameter | Value |
+| --- | --- |
+| `enabled` | `False` |
+| `support_rate` | `0` |
+
+
+### `acc_levy`
+
+| Parameter | Value |
+| --- | --- |
+| `rate` | `0.0` |
+| `max_income` | `0` |
+
+
+## 1982-1983
+
+### `_source_references`
+
+| Parameter | Value |
+| --- | --- |
+| `tax_brackets` | `{'source': 'Placeholder based on 1980-1981 data.', 'reference_ids': [], 'notes': 'NEEDS RESEARCH. The full bracket structure is unknown. The values here are placeholders and do not represent a valid tax system.'}` |
+| `ietc` | `{'source': 'Placeholder', 'notes': 'NEEDS RESEARCH. The structure of low-income tax relief in 1982 is unknown.'}` |
+| `wff` | `{'source': 'Placeholder', 'notes': 'NEEDS RESEARCH. WFF did not exist. The rules for historical family assistance programs are unknown.'}` |
+| `ppl` | `{'source': 'Placeholder', 'notes': 'NEEDS RESEARCH. Paid Parental Leave scheme of 1982 is unknown.'}` |
+| `child_support` | `{'source': 'Placeholder', 'notes': 'NEEDS RESEARCH. Child support rules for 1982 is unknown.'}` |
+| `acc_levy` | `{'source': 'Placeholder', 'notes': 'NEEDS RESEARCH. The ACC levy rate and income cap for 1982 are unknown.'}` |
+
+
+### `tax_brackets`
+
+| Parameter | Value |
+| --- | --- |
+| `rates` | `[0.6]` |
+| `thresholds` | `[]` |
+
+
+### `ietc`
+
+| Parameter | Value |
+| --- | --- |
+| `thrin` | `0` |
+| `ent` | `0` |
+| `thrab` | `0` |
+| `abrate` | `0` |
+
+
+### `wff`
+
+| Parameter | Value |
+| --- | --- |
+| `ftc1` | `0` |
+| `ftc2` | `0` |
+| `iwtc1` | `0` |
+| `iwtc2` | `0` |
+| `bstc` | `0` |
+| `mftc` | `0` |
+| `abatethresh1` | `0` |
+| `abatethresh2` | `0` |
+| `abaterate1` | `0` |
+| `abaterate2` | `0` |
+| `bstcthresh` | `0` |
+| `bstcabate` | `0` |
+
+
+### `ppl`
+
+| Parameter | Value |
+| --- | --- |
+| `enabled` | `False` |
+| `weekly_rate` | `0` |
+| `max_weeks` | `0` |
+
+
+### `child_support`
+
+| Parameter | Value |
+| --- | --- |
+| `enabled` | `False` |
+| `support_rate` | `0` |
+
+
+### `acc_levy`
+
+| Parameter | Value |
+| --- | --- |
+| `rate` | `0.0` |
+| `max_income` | `0` |
+
+
+## 1983-1984
+
+### `_source_references`
+
+| Parameter | Value |
+| --- | --- |
+| `tax_brackets` | `{'source': 'Placeholder based on 1980-1981 data.', 'reference_ids': [], 'notes': 'NEEDS RESEARCH. The full bracket structure is unknown. The values here are placeholders and do not represent a valid tax system.'}` |
+| `ietc` | `{'source': 'Placeholder', 'notes': 'NEEDS RESEARCH. The structure of low-income tax relief in 1983 is unknown.'}` |
+| `wff` | `{'source': 'Placeholder', 'notes': 'NEEDS RESEARCH. WFF did not exist. The rules for historical family assistance programs are unknown.'}` |
+| `ppl` | `{'source': 'Placeholder', 'notes': 'NEEDS RESEARCH. Paid Parental Leave scheme of 1983 is unknown.'}` |
+| `child_support` | `{'source': 'Placeholder', 'notes': 'NEEDS RESEARCH. Child support rules for 1983 is unknown.'}` |
+| `acc_levy` | `{'source': 'Placeholder', 'notes': 'NEEDS RESEARCH. The ACC levy rate and income cap for 1983 are unknown.'}` |
+
+
+### `tax_brackets`
+
+| Parameter | Value |
+| --- | --- |
+| `rates` | `[0.6]` |
+| `thresholds` | `[]` |
+
+
+### `ietc`
+
+| Parameter | Value |
+| --- | --- |
+| `thrin` | `0` |
+| `ent` | `0` |
+| `thrab` | `0` |
+| `abrate` | `0` |
+
+
+### `wff`
+
+| Parameter | Value |
+| --- | --- |
+| `ftc1` | `0` |
+| `ftc2` | `0` |
+| `iwtc1` | `0` |
+| `iwtc2` | `0` |
+| `bstc` | `0` |
+| `mftc` | `0` |
+| `abatethresh1` | `0` |
+| `abatethresh2` | `0` |
+| `abaterate1` | `0` |
+| `abaterate2` | `0` |
+| `bstcthresh` | `0` |
+| `bstcabate` | `0` |
+
+
+### `ppl`
+
+| Parameter | Value |
+| --- | --- |
+| `enabled` | `False` |
+| `weekly_rate` | `0` |
+| `max_weeks` | `0` |
+
+
+### `child_support`
+
+| Parameter | Value |
+| --- | --- |
+| `enabled` | `False` |
+| `support_rate` | `0` |
+
+
+### `acc_levy`
+
+| Parameter | Value |
+| --- | --- |
+| `rate` | `0.0` |
+| `max_income` | `0` |
+
+
+## 1984-1985
+
+### `_source_references`
+
+| Parameter | Value |
+| --- | --- |
+| `tax_brackets` | `{'source': 'Placeholder based on 1980-1981 data.', 'reference_ids': [], 'notes': 'NEEDS RESEARCH. The full bracket structure is unknown. The values here are placeholders and do not represent a valid tax system.'}` |
+| `ietc` | `{'source': 'Placeholder', 'notes': 'NEEDS RESEARCH. The structure of low-income tax relief in 1984 is unknown.'}` |
+| `wff` | `{'source': 'Placeholder', 'notes': 'NEEDS RESEARCH. WFF did not exist. The rules for historical family assistance programs are unknown.'}` |
+| `ppl` | `{'source': 'Placeholder', 'notes': 'NEEDS RESEARCH. Paid Parental Leave scheme of 1984 is unknown.'}` |
+| `child_support` | `{'source': 'Placeholder', 'notes': 'NEEDS RESEARCH. Child support rules for 1984 is unknown.'}` |
+| `acc_levy` | `{'source': 'Placeholder', 'notes': 'NEEDS RESEARCH. The ACC levy rate and income cap for 1984 are unknown.'}` |
+
+
+### `tax_brackets`
+
+| Parameter | Value |
+| --- | --- |
+| `rates` | `[0.6]` |
+| `thresholds` | `[]` |
+
+
+### `ietc`
+
+| Parameter | Value |
+| --- | --- |
+| `thrin` | `0` |
+| `ent` | `0` |
+| `thrab` | `0` |
+| `abrate` | `0` |
+
+
+### `wff`
+
+| Parameter | Value |
+| --- | --- |
+| `ftc1` | `0` |
+| `ftc2` | `0` |
+| `iwtc1` | `0` |
+| `iwtc2` | `0` |
+| `bstc` | `0` |
+| `mftc` | `0` |
+| `abatethresh1` | `0` |
+| `abatethresh2` | `0` |
+| `abaterate1` | `0` |
+| `abaterate2` | `0` |
+| `bstcthresh` | `0` |
+| `bstcabate` | `0` |
+
+
+### `ppl`
+
+| Parameter | Value |
+| --- | --- |
+| `enabled` | `False` |
+| `weekly_rate` | `0` |
+| `max_weeks` | `0` |
+
+
+### `child_support`
+
+| Parameter | Value |
+| --- | --- |
+| `enabled` | `False` |
+| `support_rate` | `0` |
+
+
+### `acc_levy`
+
+| Parameter | Value |
+| --- | --- |
+| `rate` | `0.0` |
+| `max_income` | `0` |
+
+
+## 1985-1986
+
+### `_source_references`
+
+| Parameter | Value |
+| --- | --- |
+| `tax_brackets` | `{'source': 'nz_personal_tax_rules.json: year 1985 entry', 'reference_ids': ['152018581057803-L24-L25'], 'notes': 'NEEDS RESEARCH. Source only provides the top marginal tax rate of 67%. The full bracket structure is unknown. The values here are placeholders and do not represent a valid tax system.'}` |
+| `ietc` | `{'source': 'Placeholder', 'notes': 'NEEDS RESEARCH. The structure of low-income tax relief in 1985 is unknown.'}` |
+| `wff` | `{'source': 'Placeholder', 'notes': 'NEEDS RESEARCH. WFF did not exist. The rules for historical family assistance programs are unknown.'}` |
+| `ppl` | `{'source': 'Placeholder', 'notes': 'NEEDS RESEARCH. Paid Parental Leave scheme of 1985 is unknown.'}` |
+| `child_support` | `{'source': 'Placeholder', 'notes': 'NEEDS RESEARCH. Child support rules for 1985 are unknown.'}` |
+| `acc_levy` | `{'source': 'Placeholder', 'notes': 'NEEDS RESEARCH. The ACC levy rate and income cap for 1985 are unknown.'}` |
+
+
+### `tax_brackets`
+
+| Parameter | Value |
+| --- | --- |
+| `rates` | `[0.67]` |
+| `thresholds` | `[]` |
+
+
+### `ietc`
+
+| Parameter | Value |
+| --- | --- |
+| `thrin` | `0` |
+| `ent` | `0` |
+| `thrab` | `0` |
+| `abrate` | `0` |
+
+
+### `wff`
+
+| Parameter | Value |
+| --- | --- |
+| `ftc1` | `0` |
+| `ftc2` | `0` |
+| `iwtc1` | `0` |
+| `iwtc2` | `0` |
+| `bstc` | `0` |
+| `mftc` | `0` |
+| `abatethresh1` | `0` |
+| `abatethresh2` | `0` |
+| `abaterate1` | `0` |
+| `abaterate2` | `0` |
+| `bstcthresh` | `0` |
+| `bstcabate` | `0` |
+
+
+### `ppl`
+
+| Parameter | Value |
+| --- | --- |
+| `enabled` | `False` |
+| `weekly_rate` | `0` |
+| `max_weeks` | `0` |
+
+
+### `child_support`
+
+| Parameter | Value |
+| --- | --- |
+| `enabled` | `False` |
+| `support_rate` | `0` |
+
+
+### `acc_levy`
+
+| Parameter | Value |
+| --- | --- |
+| `rate` | `0.0` |
+| `max_income` | `0` |
+
+
+## 1986-1987
+
+### `_source_references`
+
+| Parameter | Value |
+| --- | --- |
+| `tax_brackets` | `{'source': 'Placeholder based on 1985-1986 data.', 'reference_ids': [], 'notes': 'NEEDS RESEARCH. The full bracket structure is unknown. The values here are placeholders and do not represent a valid tax system.'}` |
+| `ietc` | `{'source': 'Placeholder', 'notes': 'NEEDS RESEARCH. The structure of low-income tax relief in 1986 is unknown.'}` |
+| `wff` | `{'source': 'Placeholder', 'notes': 'NEEDS RESEARCH. WFF did not exist. The rules for historical family assistance programs are unknown.'}` |
+| `ppl` | `{'source': 'Placeholder', 'notes': 'NEEDS RESEARCH. Paid Parental Leave scheme of 1986 is unknown.'}` |
+| `child_support` | `{'source': 'Placeholder', 'notes': 'NEEDS RESEARCH. Child support rules for 1986 is unknown.'}` |
+| `acc_levy` | `{'source': 'Placeholder', 'notes': 'NEEDS RESEARCH. The ACC levy rate and income cap for 1986 are unknown.'}` |
+
+
+### `tax_brackets`
+
+| Parameter | Value |
+| --- | --- |
+| `rates` | `[0.67]` |
+| `thresholds` | `[]` |
+
+
+### `ietc`
+
+| Parameter | Value |
+| --- | --- |
+| `thrin` | `0` |
+| `ent` | `0` |
+| `thrab` | `0` |
+| `abrate` | `0` |
+
+
+### `wff`
+
+| Parameter | Value |
+| --- | --- |
+| `ftc1` | `0` |
+| `ftc2` | `0` |
+| `iwtc1` | `0` |
+| `iwtc2` | `0` |
+| `bstc` | `0` |
+| `mftc` | `0` |
+| `abatethresh1` | `0` |
+| `abatethresh2` | `0` |
+| `abaterate1` | `0` |
+| `abaterate2` | `0` |
+| `bstcthresh` | `0` |
+| `bstcabate` | `0` |
+
+
+### `ppl`
+
+| Parameter | Value |
+| --- | --- |
+| `enabled` | `False` |
+| `weekly_rate` | `0` |
+| `max_weeks` | `0` |
+
+
+### `child_support`
+
+| Parameter | Value |
+| --- | --- |
+| `enabled` | `False` |
+| `support_rate` | `0` |
+
+
+### `acc_levy`
+
+| Parameter | Value |
+| --- | --- |
+| `rate` | `0.0` |
+| `max_income` | `0` |
+
+
+## 1987-1988
+
+### `_source_references`
+
+| Parameter | Value |
+| --- | --- |
+| `tax_brackets` | `{'source': 'Placeholder based on 1985-1986 data.', 'reference_ids': [], 'notes': 'NEEDS RESEARCH. The full bracket structure is unknown. The values here are placeholders and do not represent a valid tax system.'}` |
+| `ietc` | `{'source': 'Placeholder', 'notes': 'NEEDS RESEARCH. The structure of low-income tax relief in 1987 is unknown.'}` |
+| `wff` | `{'source': 'Placeholder', 'notes': 'NEEDS RESEARCH. WFF did not exist. The rules for historical family assistance programs are unknown.'}` |
+| `ppl` | `{'source': 'Placeholder', 'notes': 'NEEDS RESEARCH. Paid Parental Leave scheme of 1987 is unknown.'}` |
+| `child_support` | `{'source': 'Placeholder', 'notes': 'NEEDS RESEARCH. Child support rules for 1987 is unknown.'}` |
+| `acc_levy` | `{'source': 'Placeholder', 'notes': 'NEEDS RESEARCH. The ACC levy rate and income cap for 1987 are unknown.'}` |
+
+
+### `tax_brackets`
+
+| Parameter | Value |
+| --- | --- |
+| `rates` | `[0.67]` |
+| `thresholds` | `[]` |
+
+
+### `ietc`
+
+| Parameter | Value |
+| --- | --- |
+| `thrin` | `0` |
+| `ent` | `0` |
+| `thrab` | `0` |
+| `abrate` | `0` |
+
+
+### `wff`
+
+| Parameter | Value |
+| --- | --- |
+| `ftc1` | `0` |
+| `ftc2` | `0` |
+| `iwtc1` | `0` |
+| `iwtc2` | `0` |
+| `bstc` | `0` |
+| `mftc` | `0` |
+| `abatethresh1` | `0` |
+| `abatethresh2` | `0` |
+| `abaterate1` | `0` |
+| `abaterate2` | `0` |
+| `bstcthresh` | `0` |
+| `bstcabate` | `0` |
+
+
+### `ppl`
+
+| Parameter | Value |
+| --- | --- |
+| `enabled` | `False` |
+| `weekly_rate` | `0` |
+| `max_weeks` | `0` |
+
+
+### `child_support`
+
+| Parameter | Value |
+| --- | --- |
+| `enabled` | `False` |
+| `support_rate` | `0` |
+
+
+### `acc_levy`
+
+| Parameter | Value |
+| --- | --- |
+| `rate` | `0.0` |
+| `max_income` | `0` |
+
+
+## 1988-1989
+
+### `_source_references`
+
+| Parameter | Value |
+| --- | --- |
+| `tax_brackets` | `{'source': 'Placeholder based on 1985-1986 data.', 'reference_ids': [], 'notes': 'NEEDS RESEARCH. The full bracket structure is unknown. The values here are placeholders and do not represent a valid tax system.'}` |
+| `ietc` | `{'source': 'Placeholder', 'notes': 'NEEDS RESEARCH. The structure of low-income tax relief in 1988 is unknown.'}` |
+| `wff` | `{'source': 'Placeholder', 'notes': 'NEEDS RESEARCH. WFF did not exist. The rules for historical family assistance programs are unknown.'}` |
+| `ppl` | `{'source': 'Placeholder', 'notes': 'NEEDS RESEARCH. Paid Parental Leave scheme of 1988 is unknown.'}` |
+| `child_support` | `{'source': 'Placeholder', 'notes': 'NEEDS RESEARCH. Child support rules for 1988 is unknown.'}` |
+| `acc_levy` | `{'source': 'Placeholder', 'notes': 'NEEDS RESEARCH. The ACC levy rate and income cap for 1988 are unknown.'}` |
+
+
+### `tax_brackets`
+
+| Parameter | Value |
+| --- | --- |
+| `rates` | `[0.67]` |
+| `thresholds` | `[]` |
+
+
+### `ietc`
+
+| Parameter | Value |
+| --- | --- |
+| `thrin` | `0` |
+| `ent` | `0` |
+| `thrab` | `0` |
+| `abrate` | `0` |
+
+
+### `wff`
+
+| Parameter | Value |
+| --- | --- |
+| `ftc1` | `0` |
+| `ftc2` | `0` |
+| `iwtc1` | `0` |
+| `iwtc2` | `0` |
+| `bstc` | `0` |
+| `mftc` | `0` |
+| `abatethresh1` | `0` |
+| `abatethresh2` | `0` |
+| `abaterate1` | `0` |
+| `abaterate2` | `0` |
+| `bstcthresh` | `0` |
+| `bstcabate` | `0` |
+
+
+### `ppl`
+
+| Parameter | Value |
+| --- | --- |
+| `enabled` | `False` |
+| `weekly_rate` | `0` |
+| `max_weeks` | `0` |
+
+
+### `child_support`
+
+| Parameter | Value |
+| --- | --- |
+| `enabled` | `False` |
+| `support_rate` | `0` |
+
+
+### `acc_levy`
+
+| Parameter | Value |
+| --- | --- |
+| `rate` | `0.0` |
+| `max_income` | `0` |
+
+
+## 1989-1990
+
+### `_source_references`
+
+| Parameter | Value |
+| --- | --- |
+| `tax_brackets` | `{'source': 'Placeholder based on 1985-1986 data.', 'reference_ids': [], 'notes': 'NEEDS RESEARCH. The full bracket structure is unknown. The values here are placeholders and do not represent a valid tax system.'}` |
+| `ietc` | `{'source': 'Placeholder', 'notes': 'NEEDS RESEARCH. The structure of low-income tax relief in 1989 is unknown.'}` |
+| `wff` | `{'source': 'Placeholder', 'notes': 'NEEDS RESEARCH. WFF did not exist. The rules for historical family assistance programs are unknown.'}` |
+| `ppl` | `{'source': 'Placeholder', 'notes': 'NEEDS RESEARCH. Paid Parental Leave scheme of 1989 is unknown.'}` |
+| `child_support` | `{'source': 'Placeholder', 'notes': 'NEEDS RESEARCH. Child support rules for 1989 is unknown.'}` |
+| `acc_levy` | `{'source': 'Placeholder', 'notes': 'NEEDS RESEARCH. The ACC levy rate and income cap for 1989 are unknown.'}` |
+
+
+### `tax_brackets`
+
+| Parameter | Value |
+| --- | --- |
+| `rates` | `[0.67]` |
+| `thresholds` | `[]` |
+
+
+### `ietc`
+
+| Parameter | Value |
+| --- | --- |
+| `thrin` | `0` |
+| `ent` | `0` |
+| `thrab` | `0` |
+| `abrate` | `0` |
+
+
+### `wff`
+
+| Parameter | Value |
+| --- | --- |
+| `ftc1` | `0` |
+| `ftc2` | `0` |
+| `iwtc1` | `0` |
+| `iwtc2` | `0` |
+| `bstc` | `0` |
+| `mftc` | `0` |
+| `abatethresh1` | `0` |
+| `abatethresh2` | `0` |
+| `abaterate1` | `0` |
+| `abaterate2` | `0` |
+| `bstcthresh` | `0` |
+| `bstcabate` | `0` |
+
+
+### `ppl`
+
+| Parameter | Value |
+| --- | --- |
+| `enabled` | `False` |
+| `weekly_rate` | `0` |
+| `max_weeks` | `0` |
+
+
+### `child_support`
+
+| Parameter | Value |
+| --- | --- |
+| `enabled` | `False` |
+| `support_rate` | `0` |
+
+
+### `acc_levy`
+
+| Parameter | Value |
+| --- | --- |
+| `rate` | `0.0` |
+| `max_income` | `0` |
+
+
+## 1990-1991
+
+### `_source_references`
+
+| Parameter | Value |
+| --- | --- |
+| `tax_brackets` | `{'source': 'nz_personal_tax_rules.json: year 1990 entry', 'reference_ids': ['152018581057803-L24-L26', '152018581057803-L24-L27'], 'notes': 'Values are taken directly from the source file.'}` |
+| `ietc` | `{'source': 'Placeholder', 'notes': 'NEEDS RESEARCH. The structure of low-income tax relief in 1990 is unknown. Set to zero as a placeholder.'}` |
+| `wff` | `{'source': 'Placeholder', 'notes': 'NEEDS RESEARCH. WFF did not exist. The historical equivalent was the Family Support Tax Credit. Its rules (rates, thresholds, abatements) need to be researched and a new section may be required in the model to handle it. Set to zero as a placeholder.'}` |
+| `ppl` | `{'source': 'Placeholder', 'notes': 'NEEDS RESEARCH. Paid Parental Leave scheme of 1990 is unknown. Disabled as a placeholder.'}` |
+| `child_support` | `{'source': 'Placeholder', 'notes': 'NEEDS RESEARCH. Child support rules for 1990 are unknown. Disabled as a placeholder.'}` |
+| `acc_levy` | `{'source': 'Placeholder', 'notes': 'NEEDS RESEARCH. The ACC levy rate and income cap for 1990 are unknown. Using 2005 values as a placeholder.'}` |
+
+
+### `tax_brackets`
+
+| Parameter | Value |
+| --- | --- |
+| `rates` | `[0.24, 0.33]` |
+| `thresholds` | `[30875]` |
+
+
+### `ietc`
+
+| Parameter | Value |
+| --- | --- |
+| `thrin` | `0` |
+| `ent` | `0` |
+| `thrab` | `0` |
+| `abrate` | `0` |
+
+
+### `wff`
+
+| Parameter | Value |
+| --- | --- |
+| `ftc1` | `0` |
+| `ftc2` | `0` |
+| `iwtc1` | `0` |
+| `iwtc2` | `0` |
+| `bstc` | `0` |
+| `mftc` | `0` |
+| `abatethresh1` | `0` |
+| `abatethresh2` | `0` |
+| `abaterate1` | `0` |
+| `abaterate2` | `0` |
+| `bstcthresh` | `0` |
+| `bstcabate` | `0` |
+
+
+### `ppl`
+
+| Parameter | Value |
+| --- | --- |
+| `enabled` | `False` |
+| `weekly_rate` | `0` |
+| `max_weeks` | `0` |
+
+
+### `child_support`
+
+| Parameter | Value |
+| --- | --- |
+| `enabled` | `False` |
+| `support_rate` | `0` |
+
+
+### `acc_levy`
+
+| Parameter | Value |
+| --- | --- |
+| `rate` | `0.0153` |
+| `max_income` | `139111` |
+
+
+## 1991-1992
+
+### `_source_references`
+
+| Parameter | Value |
+| --- | --- |
+| `tax_brackets` | `{'source': 'Placeholder based on 1990-1991 data.', 'reference_ids': [], 'notes': 'NEEDS RESEARCH. The full bracket structure is unknown. The values here are placeholders and do not represent a valid tax system.'}` |
+| `ietc` | `{'source': 'Placeholder', 'notes': 'NEEDS RESEARCH. The structure of low-income tax relief in 1991 is unknown.'}` |
+| `wff` | `{'source': 'Placeholder', 'notes': 'NEEDS RESEARCH. WFF did not exist. The rules for historical family assistance programs are unknown.'}` |
+| `ppl` | `{'source': 'Placeholder', 'notes': 'NEEDS RESEARCH. Paid Parental Leave scheme of 1991 is unknown.'}` |
+| `child_support` | `{'source': 'Placeholder', 'notes': 'NEEDS RESEARCH. Child support rules for 1991 is unknown.'}` |
+| `acc_levy` | `{'source': 'Placeholder', 'notes': 'NEEDS RESEARCH. The ACC levy rate and income cap for 1991 are unknown.'}` |
+
+
+### `tax_brackets`
+
+| Parameter | Value |
+| --- | --- |
+| `rates` | `[0.24, 0.33]` |
+| `thresholds` | `[30875]` |
+
+
+### `ietc`
+
+| Parameter | Value |
+| --- | --- |
+| `thrin` | `0` |
+| `ent` | `0` |
+| `thrab` | `0` |
+| `abrate` | `0` |
+
+
+### `wff`
+
+| Parameter | Value |
+| --- | --- |
+| `ftc1` | `0` |
+| `ftc2` | `0` |
+| `iwtc1` | `0` |
+| `iwtc2` | `0` |
+| `bstc` | `0` |
+| `mftc` | `0` |
+| `abatethresh1` | `0` |
+| `abatethresh2` | `0` |
+| `abaterate1` | `0` |
+| `abaterate2` | `0` |
+| `bstcthresh` | `0` |
+| `bstcabate` | `0` |
+
+
+### `ppl`
+
+| Parameter | Value |
+| --- | --- |
+| `enabled` | `False` |
+| `weekly_rate` | `0` |
+| `max_weeks` | `0` |
+
+
+### `child_support`
+
+| Parameter | Value |
+| --- | --- |
+| `enabled` | `False` |
+| `support_rate` | `0` |
+
+
+### `acc_levy`
+
+| Parameter | Value |
+| --- | --- |
+| `rate` | `0.0153` |
+| `max_income` | `139111` |
+
+
+## 1992-1993
+
+### `_source_references`
+
+| Parameter | Value |
+| --- | --- |
+| `tax_brackets` | `{'source': 'Placeholder based on 1990-1991 data.', 'reference_ids': [], 'notes': 'NEEDS RESEARCH. The full bracket structure is unknown. The values here are placeholders and do not represent a valid tax system.'}` |
+| `ietc` | `{'source': 'Placeholder', 'notes': 'NEEDS RESEARCH. The structure of low-income tax relief in 1992 is unknown.'}` |
+| `wff` | `{'source': 'Placeholder', 'notes': 'NEEDS RESEARCH. WFF did not exist. The rules for historical family assistance programs are unknown.'}` |
+| `ppl` | `{'source': 'Placeholder', 'notes': 'NEEDS RESEARCH. Paid Parental Leave scheme of 1992 is unknown.'}` |
+| `child_support` | `{'source': 'Placeholder', 'notes': 'NEEDS RESEARCH. Child support rules for 1992 is unknown.'}` |
+| `acc_levy` | `{'source': 'Placeholder', 'notes': 'NEEDS RESEARCH. The ACC levy rate and income cap for 1992 are unknown.'}` |
+
+
+### `tax_brackets`
+
+| Parameter | Value |
+| --- | --- |
+| `rates` | `[0.24, 0.33]` |
+| `thresholds` | `[30875]` |
+
+
+### `ietc`
+
+| Parameter | Value |
+| --- | --- |
+| `thrin` | `0` |
+| `ent` | `0` |
+| `thrab` | `0` |
+| `abrate` | `0` |
+
+
+### `wff`
+
+| Parameter | Value |
+| --- | --- |
+| `ftc1` | `0` |
+| `ftc2` | `0` |
+| `iwtc1` | `0` |
+| `iwtc2` | `0` |
+| `bstc` | `0` |
+| `mftc` | `0` |
+| `abatethresh1` | `0` |
+| `abatethresh2` | `0` |
+| `abaterate1` | `0` |
+| `abaterate2` | `0` |
+| `bstcthresh` | `0` |
+| `bstcabate` | `0` |
+
+
+### `ppl`
+
+| Parameter | Value |
+| --- | --- |
+| `enabled` | `False` |
+| `weekly_rate` | `0` |
+| `max_weeks` | `0` |
+
+
+### `child_support`
+
+| Parameter | Value |
+| --- | --- |
+| `enabled` | `False` |
+| `support_rate` | `0` |
+
+
+### `acc_levy`
+
+| Parameter | Value |
+| --- | --- |
+| `rate` | `0.0153` |
+| `max_income` | `139111` |
+
+
+## 1993-1994
+
+### `_source_references`
+
+| Parameter | Value |
+| --- | --- |
+| `tax_brackets` | `{'source': 'Placeholder based on 1990-1991 data.', 'reference_ids': [], 'notes': 'NEEDS RESEARCH. The full bracket structure is unknown. The values here are placeholders and do not represent a valid tax system.'}` |
+| `ietc` | `{'source': 'Placeholder', 'notes': 'NEEDS RESEARCH. The structure of low-income tax relief in 1993 is unknown.'}` |
+| `wff` | `{'source': 'Placeholder', 'notes': 'NEEDS RESEARCH. WFF did not exist. The rules for historical family assistance programs are unknown.'}` |
+| `ppl` | `{'source': 'Placeholder', 'notes': 'NEEDS RESEARCH. Paid Parental Leave scheme of 1993 is unknown.'}` |
+| `child_support` | `{'source': 'Placeholder', 'notes': 'NEEDS RESEARCH. Child support rules for 1993 is unknown.'}` |
+| `acc_levy` | `{'source': 'Placeholder', 'notes': 'NEEDS RESEARCH. The ACC levy rate and income cap for 1993 are unknown.'}` |
+
+
+### `tax_brackets`
+
+| Parameter | Value |
+| --- | --- |
+| `rates` | `[0.24, 0.33]` |
+| `thresholds` | `[30875]` |
+
+
+### `ietc`
+
+| Parameter | Value |
+| --- | --- |
+| `thrin` | `0` |
+| `ent` | `0` |
+| `thrab` | `0` |
+| `abrate` | `0` |
+
+
+### `wff`
+
+| Parameter | Value |
+| --- | --- |
+| `ftc1` | `0` |
+| `ftc2` | `0` |
+| `iwtc1` | `0` |
+| `iwtc2` | `0` |
+| `bstc` | `0` |
+| `mftc` | `0` |
+| `abatethresh1` | `0` |
+| `abatethresh2` | `0` |
+| `abaterate1` | `0` |
+| `abaterate2` | `0` |
+| `bstcthresh` | `0` |
+| `bstcabate` | `0` |
+
+
+### `ppl`
+
+| Parameter | Value |
+| --- | --- |
+| `enabled` | `False` |
+| `weekly_rate` | `0` |
+| `max_weeks` | `0` |
+
+
+### `child_support`
+
+| Parameter | Value |
+| --- | --- |
+| `enabled` | `False` |
+| `support_rate` | `0` |
+
+
+### `acc_levy`
+
+| Parameter | Value |
+| --- | --- |
+| `rate` | `0.0153` |
+| `max_income` | `139111` |
+
+
+## 1994-1995
+
+### `_source_references`
+
+| Parameter | Value |
+| --- | --- |
+| `tax_brackets` | `{'source': 'Placeholder based on 1990-1991 data.', 'reference_ids': [], 'notes': 'NEEDS RESEARCH. The full bracket structure is unknown. The values here are placeholders and do not represent a valid tax system.'}` |
+| `ietc` | `{'source': 'Placeholder', 'notes': 'NEEDS RESEARCH. The structure of low-income tax relief in 1994 is unknown.'}` |
+| `wff` | `{'source': 'Placeholder', 'notes': 'NEEDS RESEARCH. WFF did not exist. The rules for historical family assistance programs are unknown.'}` |
+| `ppl` | `{'source': 'Placeholder', 'notes': 'NEEDS RESEARCH. Paid Parental Leave scheme of 1994 is unknown.'}` |
+| `child_support` | `{'source': 'Placeholder', 'notes': 'NEEDS RESEARCH. Child support rules for 1994 is unknown.'}` |
+| `acc_levy` | `{'source': 'Placeholder', 'notes': 'NEEDS RESEARCH. The ACC levy rate and income cap for 1994 are unknown.'}` |
+
+
+### `tax_brackets`
+
+| Parameter | Value |
+| --- | --- |
+| `rates` | `[0.24, 0.33]` |
+| `thresholds` | `[30875]` |
+
+
+### `ietc`
+
+| Parameter | Value |
+| --- | --- |
+| `thrin` | `0` |
+| `ent` | `0` |
+| `thrab` | `0` |
+| `abrate` | `0` |
+
+
+### `wff`
+
+| Parameter | Value |
+| --- | --- |
+| `ftc1` | `0` |
+| `ftc2` | `0` |
+| `iwtc1` | `0` |
+| `iwtc2` | `0` |
+| `bstc` | `0` |
+| `mftc` | `0` |
+| `abatethresh1` | `0` |
+| `abatethresh2` | `0` |
+| `abaterate1` | `0` |
+| `abaterate2` | `0` |
+| `bstcthresh` | `0` |
+| `bstcabate` | `0` |
+
+
+### `ppl`
+
+| Parameter | Value |
+| --- | --- |
+| `enabled` | `False` |
+| `weekly_rate` | `0` |
+| `max_weeks` | `0` |
+
+
+### `child_support`
+
+| Parameter | Value |
+| --- | --- |
+| `enabled` | `False` |
+| `support_rate` | `0` |
+
+
+### `acc_levy`
+
+| Parameter | Value |
+| --- | --- |
+| `rate` | `0.0153` |
+| `max_income` | `139111` |
+
+
+## 1995-1996
+
+### `_source_references`
+
+| Parameter | Value |
+| --- | --- |
+| `tax_brackets` | `{'source': 'Placeholder based on 1990-1991 data.', 'reference_ids': [], 'notes': 'NEEDS RESEARCH. The full bracket structure is unknown. The values here are placeholders and do not represent a valid tax system.'}` |
+| `ietc` | `{'source': 'Placeholder', 'notes': 'NEEDS RESEARCH. The structure of low-income tax relief in 1995 is unknown.'}` |
+| `wff` | `{'source': 'Placeholder', 'notes': 'NEEDS RESEARCH. WFF did not exist. The rules for historical family assistance programs are unknown.'}` |
+| `ppl` | `{'source': 'Placeholder', 'notes': 'NEEDS RESEARCH. Paid Parental Leave scheme of 1995 is unknown.'}` |
+| `child_support` | `{'source': 'Placeholder', 'notes': 'NEEDS RESEARCH. Child support rules for 1995 is unknown.'}` |
+| `acc_levy` | `{'source': 'Placeholder', 'notes': 'NEEDS RESEARCH. The ACC levy rate and income cap for 1995 are unknown.'}` |
+
+
+### `tax_brackets`
+
+| Parameter | Value |
+| --- | --- |
+| `rates` | `[0.24, 0.33]` |
+| `thresholds` | `[30875]` |
+
+
+### `ietc`
+
+| Parameter | Value |
+| --- | --- |
+| `thrin` | `0` |
+| `ent` | `0` |
+| `thrab` | `0` |
+| `abrate` | `0` |
+
+
+### `wff`
+
+| Parameter | Value |
+| --- | --- |
+| `ftc1` | `0` |
+| `ftc2` | `0` |
+| `iwtc1` | `0` |
+| `iwtc2` | `0` |
+| `bstc` | `0` |
+| `mftc` | `0` |
+| `abatethresh1` | `0` |
+| `abatethresh2` | `0` |
+| `abaterate1` | `0` |
+| `abaterate2` | `0` |
+| `bstcthresh` | `0` |
+| `bstcabate` | `0` |
+
+
+### `ppl`
+
+| Parameter | Value |
+| --- | --- |
+| `enabled` | `False` |
+| `weekly_rate` | `0` |
+| `max_weeks` | `0` |
+
+
+### `child_support`
+
+| Parameter | Value |
+| --- | --- |
+| `enabled` | `False` |
+| `support_rate` | `0` |
+
+
+### `acc_levy`
+
+| Parameter | Value |
+| --- | --- |
+| `rate` | `0.0153` |
+| `max_income` | `139111` |
+
+
+## 1996-1997
+
+### `_source_references`
+
+| Parameter | Value |
+| --- | --- |
+| `tax_brackets` | `{'source': 'Placeholder based on 1990-1991 data.', 'reference_ids': [], 'notes': 'NEEDS RESEARCH. The full bracket structure is unknown. The values here are placeholders and do not represent a valid tax system.'}` |
+| `ietc` | `{'source': 'Placeholder', 'notes': 'NEEDS RESEARCH. The structure of low-income tax relief in 1996 is unknown.'}` |
+| `wff` | `{'source': 'Placeholder', 'notes': 'NEEDS RESEARCH. WFF did not exist. The rules for historical family assistance programs are unknown.'}` |
+| `ppl` | `{'source': 'Placeholder', 'notes': 'NEEDS RESEARCH. Paid Parental Leave scheme of 1996 is unknown.'}` |
+| `child_support` | `{'source': 'Placeholder', 'notes': 'NEEDS RESEARCH. Child support rules for 1996 is unknown.'}` |
+| `acc_levy` | `{'source': 'Placeholder', 'notes': 'NEEDS RESEARCH. The ACC levy rate and income cap for 1996 are unknown.'}` |
+
+
+### `tax_brackets`
+
+| Parameter | Value |
+| --- | --- |
+| `rates` | `[0.24, 0.33]` |
+| `thresholds` | `[30875]` |
+
+
+### `ietc`
+
+| Parameter | Value |
+| --- | --- |
+| `thrin` | `0` |
+| `ent` | `0` |
+| `thrab` | `0` |
+| `abrate` | `0` |
+
+
+### `wff`
+
+| Parameter | Value |
+| --- | --- |
+| `ftc1` | `0` |
+| `ftc2` | `0` |
+| `iwtc1` | `0` |
+| `iwtc2` | `0` |
+| `bstc` | `0` |
+| `mftc` | `0` |
+| `abatethresh1` | `0` |
+| `abatethresh2` | `0` |
+| `abaterate1` | `0` |
+| `abaterate2` | `0` |
+| `bstcthresh` | `0` |
+| `bstcabate` | `0` |
+
+
+### `ppl`
+
+| Parameter | Value |
+| --- | --- |
+| `enabled` | `False` |
+| `weekly_rate` | `0` |
+| `max_weeks` | `0` |
+
+
+### `child_support`
+
+| Parameter | Value |
+| --- | --- |
+| `enabled` | `False` |
+| `support_rate` | `0` |
+
+
+### `acc_levy`
+
+| Parameter | Value |
+| --- | --- |
+| `rate` | `0.0153` |
+| `max_income` | `139111` |
+
+
+## 1997-1998
+
+### `_source_references`
+
+| Parameter | Value |
+| --- | --- |
+| `tax_brackets` | `{'source': 'Placeholder based on 1990-1991 data.', 'reference_ids': [], 'notes': 'NEEDS RESEARCH. The full bracket structure is unknown. The values here are placeholders and do not represent a valid tax system.'}` |
+| `ietc` | `{'source': 'Placeholder', 'notes': 'NEEDS RESEARCH. The structure of low-income tax relief in 1997 is unknown.'}` |
+| `wff` | `{'source': 'Placeholder', 'notes': 'NEEDS RESEARCH. WFF did not exist. The rules for historical family assistance programs are unknown.'}` |
+| `ppl` | `{'source': 'Placeholder', 'notes': 'NEEDS RESEARCH. Paid Parental Leave scheme of 1997 is unknown.'}` |
+| `child_support` | `{'source': 'Placeholder', 'notes': 'NEEDS RESEARCH. Child support rules for 1997 is unknown.'}` |
+| `acc_levy` | `{'source': 'Placeholder', 'notes': 'NEEDS RESEARCH. The ACC levy rate and income cap for 1997 are unknown.'}` |
+
+
+### `tax_brackets`
+
+| Parameter | Value |
+| --- | --- |
+| `rates` | `[0.24, 0.33]` |
+| `thresholds` | `[30875]` |
+
+
+### `ietc`
+
+| Parameter | Value |
+| --- | --- |
+| `thrin` | `0` |
+| `ent` | `0` |
+| `thrab` | `0` |
+| `abrate` | `0` |
+
+
+### `wff`
+
+| Parameter | Value |
+| --- | --- |
+| `ftc1` | `0` |
+| `ftc2` | `0` |
+| `iwtc1` | `0` |
+| `iwtc2` | `0` |
+| `bstc` | `0` |
+| `mftc` | `0` |
+| `abatethresh1` | `0` |
+| `abatethresh2` | `0` |
+| `abaterate1` | `0` |
+| `abaterate2` | `0` |
+| `bstcthresh` | `0` |
+| `bstcabate` | `0` |
+
+
+### `ppl`
+
+| Parameter | Value |
+| --- | --- |
+| `enabled` | `False` |
+| `weekly_rate` | `0` |
+| `max_weeks` | `0` |
+
+
+### `child_support`
+
+| Parameter | Value |
+| --- | --- |
+| `enabled` | `False` |
+| `support_rate` | `0` |
+
+
+### `acc_levy`
+
+| Parameter | Value |
+| --- | --- |
+| `rate` | `0.0153` |
+| `max_income` | `139111` |
+
+
+## 1998-1999
+
+### `_source_references`
+
+| Parameter | Value |
+| --- | --- |
+| `tax_brackets` | `{'source': 'Placeholder based on 1990-1991 data.', 'reference_ids': [], 'notes': 'NEEDS RESEARCH. The full bracket structure is unknown. The values here are placeholders and do not represent a valid tax system.'}` |
+| `ietc` | `{'source': 'Placeholder', 'notes': 'NEEDS RESEARCH. The structure of low-income tax relief in 1998 is unknown.'}` |
+| `wff` | `{'source': 'Placeholder', 'notes': 'NEEDS RESEARCH. WFF did not exist. The rules for historical family assistance programs are unknown.'}` |
+| `ppl` | `{'source': 'Placeholder', 'notes': 'NEEDS RESEARCH. Paid Parental Leave scheme of 1998 is unknown.'}` |
+| `child_support` | `{'source': 'Placeholder', 'notes': 'NEEDS RESEARCH. Child support rules for 1998 is unknown.'}` |
+| `acc_levy` | `{'source': 'Placeholder', 'notes': 'NEEDS RESEARCH. The ACC levy rate and income cap for 1998 are unknown.'}` |
+
+
+### `tax_brackets`
+
+| Parameter | Value |
+| --- | --- |
+| `rates` | `[0.24, 0.33]` |
+| `thresholds` | `[30875]` |
+
+
+### `ietc`
+
+| Parameter | Value |
+| --- | --- |
+| `thrin` | `0` |
+| `ent` | `0` |
+| `thrab` | `0` |
+| `abrate` | `0` |
+
+
+### `wff`
+
+| Parameter | Value |
+| --- | --- |
+| `ftc1` | `0` |
+| `ftc2` | `0` |
+| `iwtc1` | `0` |
+| `iwtc2` | `0` |
+| `bstc` | `0` |
+| `mftc` | `0` |
+| `abatethresh1` | `0` |
+| `abatethresh2` | `0` |
+| `abaterate1` | `0` |
+| `abaterate2` | `0` |
+| `bstcthresh` | `0` |
+| `bstcabate` | `0` |
+
+
+### `ppl`
+
+| Parameter | Value |
+| --- | --- |
+| `enabled` | `False` |
+| `weekly_rate` | `0` |
+| `max_weeks` | `0` |
+
+
+### `child_support`
+
+| Parameter | Value |
+| --- | --- |
+| `enabled` | `False` |
+| `support_rate` | `0` |
+
+
+### `acc_levy`
+
+| Parameter | Value |
+| --- | --- |
+| `rate` | `0.0153` |
+| `max_income` | `139111` |
+
+
+## 1999-2000
+
+### `_source_references`
+
+| Parameter | Value |
+| --- | --- |
+| `tax_brackets` | `{'source': 'Placeholder based on 1990-1991 data.', 'reference_ids': [], 'notes': 'NEEDS RESEARCH. The full bracket structure is unknown. The values here are placeholders and do not represent a valid tax system.'}` |
+| `ietc` | `{'source': 'Placeholder', 'notes': 'NEEDS RESEARCH. The structure of low-income tax relief in 1999 is unknown.'}` |
+| `wff` | `{'source': 'Placeholder', 'notes': 'NEEDS RESEARCH. WFF did not exist. The rules for historical family assistance programs are unknown.'}` |
+| `ppl` | `{'source': 'Placeholder', 'notes': 'NEEDS RESEARCH. Paid Parental Leave scheme of 1999 is unknown.'}` |
+| `child_support` | `{'source': 'Placeholder', 'notes': 'NEEDS RESEARCH. Child support rules for 1999 is unknown.'}` |
+| `acc_levy` | `{'source': 'Placeholder', 'notes': 'NEEDS RESEARCH. The ACC levy rate and income cap for 1999 are unknown.'}` |
+
+
+### `tax_brackets`
+
+| Parameter | Value |
+| --- | --- |
+| `rates` | `[0.24, 0.33]` |
+| `thresholds` | `[30875]` |
+
+
+### `ietc`
+
+| Parameter | Value |
+| --- | --- |
+| `thrin` | `0` |
+| `ent` | `0` |
+| `thrab` | `0` |
+| `abrate` | `0` |
+
+
+### `wff`
+
+| Parameter | Value |
+| --- | --- |
+| `ftc1` | `0` |
+| `ftc2` | `0` |
+| `iwtc1` | `0` |
+| `iwtc2` | `0` |
+| `bstc` | `0` |
+| `mftc` | `0` |
+| `abatethresh1` | `0` |
+| `abatethresh2` | `0` |
+| `abaterate1` | `0` |
+| `abaterate2` | `0` |
+| `bstcthresh` | `0` |
+| `bstcabate` | `0` |
+
+
+### `ppl`
+
+| Parameter | Value |
+| --- | --- |
+| `enabled` | `False` |
+| `weekly_rate` | `0` |
+| `max_weeks` | `0` |
+
+
+### `child_support`
+
+| Parameter | Value |
+| --- | --- |
+| `enabled` | `False` |
+| `support_rate` | `0` |
+
+
+### `acc_levy`
+
+| Parameter | Value |
+| --- | --- |
+| `rate` | `0.0153` |
+| `max_income` | `139111` |
+
+
+## 2000-2001
+
+### `tax_brackets`
+
+| Parameter | Value |
+| --- | --- |
+| `rates` | `[0.15, 0.21, 0.33, 0.39]` |
+| `thresholds` | `[9500, 38000, 60000]` |
+
+
+### `ietc`
+
+| Parameter | Value |
+| --- | --- |
+| `thrin` | `0` |
+| `ent` | `0` |
+| `thrab` | `0` |
+| `abrate` | `0` |
+
+
+### `wff`
+
+| Parameter | Value |
+| --- | --- |
+| `ftc1` | `0` |
+| `ftc2` | `0` |
+| `iwtc1` | `0` |
+| `iwtc2` | `0` |
+| `bstc` | `0` |
+| `mftc` | `0` |
+| `abatethresh1` | `0` |
+| `abatethresh2` | `0` |
+| `abaterate1` | `0` |
+| `abaterate2` | `0` |
+| `bstcthresh` | `0` |
+| `bstcabate` | `0` |
+
+
+### `ppl`
+
+| Parameter | Value |
+| --- | --- |
+| `enabled` | `False` |
+| `weekly_rate` | `0` |
+| `max_weeks` | `0` |
+
+
+### `child_support`
+
+| Parameter | Value |
+| --- | --- |
+| `enabled` | `False` |
+| `support_rate` | `0` |
+
+
+### `acc_levy`
+
+| Parameter | Value |
+| --- | --- |
+| `rate` | `0.0153` |
+| `max_income` | `139111` |
+
+
+## 2001-2002
+
+### `_source_references`
+
+| Parameter | Value |
+| --- | --- |
+| `tax_brackets` | `{'source': 'Placeholder based on 2000-2001 data.', 'reference_ids': [], 'notes': 'NEEDS RESEARCH. The full bracket structure is unknown. The values here are placeholders and do not represent a valid tax system.'}` |
+| `ietc` | `{'source': 'Placeholder', 'notes': 'NEEDS RESEARCH. The structure of low-income tax relief in 2001 is unknown.'}` |
+| `wff` | `{'source': 'Placeholder', 'notes': 'NEEDS RESEARCH. WFF did not exist. The rules for historical family assistance programs are unknown.'}` |
+| `ppl` | `{'source': 'Placeholder', 'notes': 'NEEDS RESEARCH. Paid Parental Leave scheme of 2001 is unknown.'}` |
+| `child_support` | `{'source': 'Placeholder', 'notes': 'NEEDS RESEARCH. Child support rules for 2001 is unknown.'}` |
+| `acc_levy` | `{'source': 'Placeholder', 'notes': 'NEEDS RESEARCH. The ACC levy rate and income cap for 2001 are unknown.'}` |
+
+
+### `tax_brackets`
+
+| Parameter | Value |
+| --- | --- |
+| `rates` | `[0.15, 0.21, 0.33, 0.39]` |
+| `thresholds` | `[9500, 38000, 60000]` |
+
+
+### `ietc`
+
+| Parameter | Value |
+| --- | --- |
+| `thrin` | `0` |
+| `ent` | `0` |
+| `thrab` | `0` |
+| `abrate` | `0` |
+
+
+### `wff`
+
+| Parameter | Value |
+| --- | --- |
+| `ftc1` | `0` |
+| `ftc2` | `0` |
+| `iwtc1` | `0` |
+| `iwtc2` | `0` |
+| `bstc` | `0` |
+| `mftc` | `0` |
+| `abatethresh1` | `0` |
+| `abatethresh2` | `0` |
+| `abaterate1` | `0` |
+| `abaterate2` | `0` |
+| `bstcthresh` | `0` |
+| `bstcabate` | `0` |
+
+
+### `ppl`
+
+| Parameter | Value |
+| --- | --- |
+| `enabled` | `False` |
+| `weekly_rate` | `0` |
+| `max_weeks` | `0` |
+
+
+### `child_support`
+
+| Parameter | Value |
+| --- | --- |
+| `enabled` | `False` |
+| `support_rate` | `0` |
+
+
+### `acc_levy`
+
+| Parameter | Value |
+| --- | --- |
+| `rate` | `0.0153` |
+| `max_income` | `139111` |
+
+
+## 2002-2003
+
+### `_source_references`
+
+| Parameter | Value |
+| --- | --- |
+| `tax_brackets` | `{'source': 'Placeholder based on 2000-2001 data.', 'reference_ids': [], 'notes': 'NEEDS RESEARCH. The full bracket structure is unknown. The values here are placeholders and do not represent a valid tax system.'}` |
+| `ietc` | `{'source': 'Placeholder', 'notes': 'NEEDS RESEARCH. The structure of low-income tax relief in 2002 is unknown.'}` |
+| `wff` | `{'source': 'Placeholder', 'notes': 'NEEDS RESEARCH. WFF did not exist. The rules for historical family assistance programs are unknown.'}` |
+| `ppl` | `{'source': 'Placeholder', 'notes': 'NEEDS RESEARCH. Paid Parental Leave scheme of 2002 is unknown.'}` |
+| `child_support` | `{'source': 'Placeholder', 'notes': 'NEEDS RESEARCH. Child support rules for 2002 is unknown.'}` |
+| `acc_levy` | `{'source': 'Placeholder', 'notes': 'NEEDS RESEARCH. The ACC levy rate and income cap for 2002 are unknown.'}` |
+
+
+### `tax_brackets`
+
+| Parameter | Value |
+| --- | --- |
+| `rates` | `[0.15, 0.21, 0.33, 0.39]` |
+| `thresholds` | `[9500, 38000, 60000]` |
+
+
+### `ietc`
+
+| Parameter | Value |
+| --- | --- |
+| `thrin` | `0` |
+| `ent` | `0` |
+| `thrab` | `0` |
+| `abrate` | `0` |
+
+
+### `wff`
+
+| Parameter | Value |
+| --- | --- |
+| `ftc1` | `0` |
+| `ftc2` | `0` |
+| `iwtc1` | `0` |
+| `iwtc2` | `0` |
+| `bstc` | `0` |
+| `mftc` | `0` |
+| `abatethresh1` | `0` |
+| `abatethresh2` | `0` |
+| `abaterate1` | `0` |
+| `abaterate2` | `0` |
+| `bstcthresh` | `0` |
+| `bstcabate` | `0` |
+
+
+### `ppl`
+
+| Parameter | Value |
+| --- | --- |
+| `enabled` | `False` |
+| `weekly_rate` | `0` |
+| `max_weeks` | `0` |
+
+
+### `child_support`
+
+| Parameter | Value |
+| --- | --- |
+| `enabled` | `False` |
+| `support_rate` | `0` |
+
+
+### `acc_levy`
+
+| Parameter | Value |
+| --- | --- |
+| `rate` | `0.0153` |
+| `max_income` | `139111` |
+
+
+## 2003-2004
+
+### `_source_references`
+
+| Parameter | Value |
+| --- | --- |
+| `tax_brackets` | `{'source': 'Placeholder based on 2000-2001 data.', 'reference_ids': [], 'notes': 'NEEDS RESEARCH. The full bracket structure is unknown. The values here are placeholders and do not represent a valid tax system.'}` |
+| `ietc` | `{'source': 'Placeholder', 'notes': 'NEEDS RESEARCH. The structure of low-income tax relief in 2003 is unknown.'}` |
+| `wff` | `{'source': 'Placeholder', 'notes': 'NEEDS RESEARCH. WFF did not exist. The rules for historical family assistance programs are unknown.'}` |
+| `ppl` | `{'source': 'Placeholder', 'notes': 'NEEDS RESEARCH. Paid Parental Leave scheme of 2003 is unknown.'}` |
+| `child_support` | `{'source': 'Placeholder', 'notes': 'NEEDS RESEARCH. Child support rules for 2003 is unknown.'}` |
+| `acc_levy` | `{'source': 'Placeholder', 'notes': 'NEEDS RESEARCH. The ACC levy rate and income cap for 2003 are unknown.'}` |
+
+
+### `tax_brackets`
+
+| Parameter | Value |
+| --- | --- |
+| `rates` | `[0.15, 0.21, 0.33, 0.39]` |
+| `thresholds` | `[9500, 38000, 60000]` |
+
+
+### `ietc`
+
+| Parameter | Value |
+| --- | --- |
+| `thrin` | `0` |
+| `ent` | `0` |
+| `thrab` | `0` |
+| `abrate` | `0` |
+
+
+### `wff`
+
+| Parameter | Value |
+| --- | --- |
+| `ftc1` | `0` |
+| `ftc2` | `0` |
+| `iwtc1` | `0` |
+| `iwtc2` | `0` |
+| `bstc` | `0` |
+| `mftc` | `0` |
+| `abatethresh1` | `0` |
+| `abatethresh2` | `0` |
+| `abaterate1` | `0` |
+| `abaterate2` | `0` |
+| `bstcthresh` | `0` |
+| `bstcabate` | `0` |
+
+
+### `ppl`
+
+| Parameter | Value |
+| --- | --- |
+| `enabled` | `False` |
+| `weekly_rate` | `0` |
+| `max_weeks` | `0` |
+
+
+### `child_support`
+
+| Parameter | Value |
+| --- | --- |
+| `enabled` | `False` |
+| `support_rate` | `0` |
+
+
+### `acc_levy`
+
+| Parameter | Value |
+| --- | --- |
+| `rate` | `0.0153` |
+| `max_income` | `139111` |
+
+
+## 2004-2005
+
+### `_source_references`
+
+| Parameter | Value |
+| --- | --- |
+| `tax_brackets` | `{'source': 'Placeholder based on 2000-2001 data.', 'reference_ids': [], 'notes': 'NEEDS RESEARCH. The full bracket structure is unknown. The values here are placeholders and do not represent a valid tax system.'}` |
+| `ietc` | `{'source': 'Placeholder', 'notes': 'NEEDS RESEARCH. The structure of low-income tax relief in 2004 is unknown.'}` |
+| `wff` | `{'source': 'Placeholder', 'notes': 'NEEDS RESEARCH. WFF did not exist. The rules for historical family assistance programs are unknown.'}` |
+| `ppl` | `{'source': 'Placeholder', 'notes': 'NEEDS RESEARCH. Paid Parental Leave scheme of 2004 is unknown.'}` |
+| `child_support` | `{'source': 'Placeholder', 'notes': 'NEEDS RESEARCH. Child support rules for 2004 is unknown.'}` |
+| `acc_levy` | `{'source': 'Placeholder', 'notes': 'NEEDS RESEARCH. The ACC levy rate and income cap for 2004 are unknown.'}` |
+
+
+### `tax_brackets`
+
+| Parameter | Value |
+| --- | --- |
+| `rates` | `[0.15, 0.21, 0.33, 0.39]` |
+| `thresholds` | `[9500, 38000, 60000]` |
+
+
+### `ietc`
+
+| Parameter | Value |
+| --- | --- |
+| `thrin` | `0` |
+| `ent` | `0` |
+| `thrab` | `0` |
+| `abrate` | `0` |
+
+
+### `wff`
+
+| Parameter | Value |
+| --- | --- |
+| `ftc1` | `0` |
+| `ftc2` | `0` |
+| `iwtc1` | `0` |
+| `iwtc2` | `0` |
+| `bstc` | `0` |
+| `mftc` | `0` |
+| `abatethresh1` | `0` |
+| `abatethresh2` | `0` |
+| `abaterate1` | `0` |
+| `abaterate2` | `0` |
+| `bstcthresh` | `0` |
+| `bstcabate` | `0` |
+
+
+### `ppl`
+
+| Parameter | Value |
+| --- | --- |
+| `enabled` | `False` |
+| `weekly_rate` | `0` |
+| `max_weeks` | `0` |
+
+
+### `child_support`
+
+| Parameter | Value |
+| --- | --- |
+| `enabled` | `False` |
+| `support_rate` | `0` |
+
+
+### `acc_levy`
+
+| Parameter | Value |
+| --- | --- |
+| `rate` | `0.0153` |
+| `max_income` | `139111` |
+
+
+## 2005-2006
+
+### `tax_brackets`
+
+| Parameter | Value |
+| --- | --- |
+| `rates` | `[0.195, 0.33, 0.39]` |
+| `thresholds` | `[38000, 60000]` |
+
+
+### `ietc`
+
+| Parameter | Value |
+| --- | --- |
+| `thrin` | `520` |
+| `ent` | `1040` |
+| `thrab` | `50000` |
+| `abrate` | `0.1` |
+
+
+### `wff`
+
+| Parameter | Value |
+| --- | --- |
+| `ftc1` | `2730` |
+| `ftc2` | `2730` |
+| `iwtc1` | `2080` |
+| `iwtc2` | `0` |
+| `bstc` | `0` |
+| `mftc` | `17680` |
+| `abatethresh1` | `20356` |
+| `abatethresh2` | `20356` |
+| `abaterate1` | `0.18` |
+| `abaterate2` | `0.3` |
+| `bstcthresh` | `0` |
+| `bstcabate` | `0` |
+
+
+### `ppl`
+
+| Parameter | Value |
+| --- | --- |
+| `enabled` | `False` |
+| `weekly_rate` | `712.17` |
+| `max_weeks` | `26` |
+
+
+### `child_support`
+
+| Parameter | Value |
+| --- | --- |
+| `enabled` | `False` |
+| `support_rate` | `0.18` |
+
+
+### `acc_levy`
+
+| Parameter | Value |
+| --- | --- |
+| `rate` | `0.0153` |
+| `max_income` | `139111` |
+
+
+## 2006-2007
+
+### `tax_brackets`
+
+| Parameter | Value |
+| --- | --- |
+| `rates` | `[0.15, 0.29, 0.39, 0.45]` |
+| `thresholds` | `[9500, 34000, 60000]` |
+
+
+### `ietc`
+
+| Parameter | Value |
+| --- | --- |
+| `thrin` | `520` |
+| `ent` | `1040` |
+| `thrab` | `50000` |
+| `abrate` | `0.1` |
+
+
+### `wff`
+
+| Parameter | Value |
+| --- | --- |
+| `ftc1` | `4446` |
+| `ftc2` | `3351` |
+| `iwtc1` | `2080` |
+| `iwtc2` | `0` |
+| `bstc` | `0` |
+| `mftc` | `18980` |
+| `abatethresh1` | `27548` |
+| `abatethresh2` | `27548` |
+| `abaterate1` | `0.3` |
+| `abaterate2` | `0.3` |
+| `bstcthresh` | `0` |
+| `bstcabate` | `0` |
+
+
+### `ppl`
+
+| Parameter | Value |
+| --- | --- |
+| `enabled` | `False` |
+| `weekly_rate` | `712.17` |
+| `max_weeks` | `26` |
+
+
+### `child_support`
+
+| Parameter | Value |
+| --- | --- |
+| `enabled` | `False` |
+| `support_rate` | `0.18` |
+
+
+### `acc_levy`
+
+| Parameter | Value |
+| --- | --- |
+| `rate` | `0.0153` |
+| `max_income` | `139111` |
+
+
+## 2007-2008
+
+### `tax_brackets`
+
+| Parameter | Value |
+| --- | --- |
+| `rates` | `[0.15, 0.29, 0.39, 0.45]` |
+| `thresholds` | `[9500, 34000, 60000]` |
+
+
+### `ietc`
+
+| Parameter | Value |
+| --- | --- |
+| `thrin` | `520` |
+| `ent` | `1040` |
+| `thrab` | `50000` |
+| `abrate` | `0.1` |
+
+
+### `wff`
+
+| Parameter | Value |
+| --- | --- |
+| `ftc1` | `4446` |
+| `ftc2` | `3351` |
+| `iwtc1` | `2080` |
+| `iwtc2` | `0` |
+| `bstc` | `0` |
+| `mftc` | `19760` |
+| `abatethresh1` | `35000` |
+| `abatethresh2` | `35000` |
+| `abaterate1` | `0.2` |
+| `abaterate2` | `0.2` |
+| `bstcthresh` | `0` |
+| `bstcabate` | `0` |
+
+
+### `ppl`
+
+| Parameter | Value |
+| --- | --- |
+| `enabled` | `False` |
+| `weekly_rate` | `712.17` |
+| `max_weeks` | `26` |
+
+
+### `child_support`
+
+| Parameter | Value |
+| --- | --- |
+| `enabled` | `False` |
+| `support_rate` | `0.18` |
+
+
+### `acc_levy`
+
+| Parameter | Value |
+| --- | --- |
+| `rate` | `0.0153` |
+| `max_income` | `139111` |
+
+
+## 2008-2009
+
+### `tax_brackets`
+
+| Parameter | Value |
+| --- | --- |
+| `rates` | `[0.15, 0.29, 0.39, 0.45]` |
+| `thresholds` | `[9500, 34000, 60000]` |
+
+
+### `ietc`
+
+| Parameter | Value |
+| --- | --- |
+| `thrin` | `520` |
+| `ent` | `1040` |
+| `thrab` | `50000` |
+| `abrate` | `0.1` |
+
+
+### `wff`
+
+| Parameter | Value |
+| --- | --- |
+| `ftc1` | `4822` |
+| `ftc2` | `3351` |
+| `iwtc1` | `3120` |
+| `iwtc2` | `0` |
+| `bstc` | `0` |
+| `mftc` | `22100` |
+| `abatethresh1` | `36827` |
+| `abatethresh2` | `36827` |
+| `abaterate1` | `0.2` |
+| `abaterate2` | `0.2` |
+| `bstcthresh` | `0` |
+| `bstcabate` | `0` |
+
+
+### `ppl`
+
+| Parameter | Value |
+| --- | --- |
+| `enabled` | `False` |
+| `weekly_rate` | `712.17` |
+| `max_weeks` | `26` |
+
+
+### `child_support`
+
+| Parameter | Value |
+| --- | --- |
+| `enabled` | `False` |
+| `support_rate` | `0.18` |
+
+
+### `acc_levy`
+
+| Parameter | Value |
+| --- | --- |
+| `rate` | `0.0153` |
+| `max_income` | `139111` |
+
+
+## 2009-2010
+
+### `tax_brackets`
+
+| Parameter | Value |
+| --- | --- |
+| `rates` | `[0.125, 0.21, 0.33, 0.38]` |
+| `thresholds` | `[14000, 40000, 70000]` |
+
+
+### `ietc`
+
+| Parameter | Value |
+| --- | --- |
+| `thrin` | `520` |
+| `ent` | `1040` |
+| `thrab` | `50000` |
+| `abrate` | `0.1` |
+
+
+### `wff`
+
+| Parameter | Value |
+| --- | --- |
+| `ftc1` | `4822` |
+| `ftc2` | `3351` |
+| `iwtc1` | `3120` |
+| `iwtc2` | `0` |
+| `bstc` | `0` |
+| `mftc` | `22100` |
+| `abatethresh1` | `36827` |
+| `abatethresh2` | `36827` |
+| `abaterate1` | `0.2` |
+| `abaterate2` | `0.2` |
+| `bstcthresh` | `0` |
+| `bstcabate` | `0` |
+
+
+### `ppl`
+
+| Parameter | Value |
+| --- | --- |
+| `enabled` | `False` |
+| `weekly_rate` | `712.17` |
+| `max_weeks` | `26` |
+
+
+### `child_support`
+
+| Parameter | Value |
+| --- | --- |
+| `enabled` | `False` |
+| `support_rate` | `0.18` |
+
+
+### `acc_levy`
+
+| Parameter | Value |
+| --- | --- |
+| `rate` | `0.0153` |
+| `max_income` | `139111` |
+
+
+## 2010-2011
+
+### `tax_brackets`
+
+| Parameter | Value |
+| --- | --- |
+| `rates` | `[0.125, 0.22, 0.33, 0.38]` |
+| `thresholds` | `[14000, 48000, 70000]` |
+
+
+### `ietc`
+
+| Parameter | Value |
+| --- | --- |
+| `thrin` | `24000` |
+| `ent` | `1040` |
+| `thrab` | `44000` |
+| `abrate` | `0.15` |
+
+
+### `wff`
+
+| Parameter | Value |
+| --- | --- |
+| `ftc1` | `4822` |
+| `ftc2` | `3351` |
+| `iwtc1` | `3120` |
+| `iwtc2` | `0` |
+| `bstc` | `0` |
+| `mftc` | `22100` |
+| `abatethresh1` | `36827` |
+| `abatethresh2` | `36827` |
+| `abaterate1` | `0.2` |
+| `abaterate2` | `0.2` |
+| `bstcthresh` | `0` |
+| `bstcabate` | `0` |
+
+
+### `ppl`
+
+| Parameter | Value |
+| --- | --- |
+| `enabled` | `False` |
+| `weekly_rate` | `712.17` |
+| `max_weeks` | `26` |
+
+
+### `child_support`
+
+| Parameter | Value |
+| --- | --- |
+| `enabled` | `False` |
+| `support_rate` | `0.18` |
+
+
+### `acc_levy`
+
+| Parameter | Value |
+| --- | --- |
+| `rate` | `0.0153` |
+| `max_income` | `139111` |
+
+
+## 2011-2012
+
+### `tax_brackets`
+
+| Parameter | Value |
+| --- | --- |
+| `rates` | `[0.105, 0.175, 0.3, 0.33]` |
+| `thresholds` | `[14000, 48000, 70000]` |
+
+
+### `ietc`
+
+| Parameter | Value |
+| --- | --- |
+| `thrin` | `24000` |
+| `ent` | `520` |
+| `thrab` | `48000` |
+| `abrate` | `0.15` |
+
+
+### `wff`
+
+| Parameter | Value |
+| --- | --- |
+| `ftc1` | `4822` |
+| `ftc2` | `3351` |
+| `iwtc1` | `3770` |
+| `iwtc2` | `0` |
+| `bstc` | `0` |
+| `mftc` | `23036` |
+| `abatethresh1` | `36350` |
+| `abatethresh2` | `36350` |
+| `abaterate1` | `0.225` |
+| `abaterate2` | `0.225` |
+| `bstcthresh` | `0` |
+| `bstcabate` | `0` |
+
+
+### `ppl`
+
+| Parameter | Value |
+| --- | --- |
+| `enabled` | `False` |
+| `weekly_rate` | `712.17` |
+| `max_weeks` | `26` |
+
+
+### `child_support`
+
+| Parameter | Value |
+| --- | --- |
+| `enabled` | `False` |
+| `support_rate` | `0.18` |
+
+
+### `acc_levy`
+
+| Parameter | Value |
+| --- | --- |
+| `rate` | `0.0153` |
+| `max_income` | `139111` |
+
+
+## 2012-2013
+
+### `tax_brackets`
+
+| Parameter | Value |
+| --- | --- |
+| `rates` | `[0.105, 0.175, 0.3, 0.33]` |
+| `thresholds` | `[14000, 48000, 70000]` |
+
+
+### `ietc`
+
+| Parameter | Value |
+| --- | --- |
+| `thrin` | `24000` |
+| `ent` | `520` |
+| `thrab` | `48000` |
+| `abrate` | `0.15` |
+
+
+### `wff`
+
+| Parameter | Value |
+| --- | --- |
+| `ftc1` | `4822` |
+| `ftc2` | `3351` |
+| `iwtc1` | `3770` |
+| `iwtc2` | `0` |
+| `bstc` | `0` |
+| `mftc` | `23036` |
+| `abatethresh1` | `36350` |
+| `abatethresh2` | `36350` |
+| `abaterate1` | `0.225` |
+| `abaterate2` | `0.225` |
+| `bstcthresh` | `0` |
+| `bstcabate` | `0` |
+
+
+### `ppl`
+
+| Parameter | Value |
+| --- | --- |
+| `enabled` | `False` |
+| `weekly_rate` | `712.17` |
+| `max_weeks` | `26` |
+
+
+### `child_support`
+
+| Parameter | Value |
+| --- | --- |
+| `enabled` | `False` |
+| `support_rate` | `0.18` |
+
+
+### `acc_levy`
+
+| Parameter | Value |
+| --- | --- |
+| `rate` | `0.0153` |
+| `max_income` | `139111` |
+
+
+## 2013-2014
+
+### `tax_brackets`
+
+| Parameter | Value |
+| --- | --- |
+| `rates` | `[0.105, 0.175, 0.3, 0.33]` |
+| `thresholds` | `[14000, 48000, 70000]` |
+
+
+### `ietc`
+
+| Parameter | Value |
+| --- | --- |
+| `thrin` | `24000` |
+| `ent` | `520` |
+| `thrab` | `48000` |
+| `abrate` | `0.13` |
+
+
+### `wff`
+
+| Parameter | Value |
+| --- | --- |
+| `ftc1` | `4822` |
+| `ftc2` | `3351` |
+| `iwtc1` | `3770` |
+| `iwtc2` | `0` |
+| `bstc` | `0` |
+| `mftc` | `23036` |
+| `abatethresh1` | `36350` |
+| `abatethresh2` | `36350` |
+| `abaterate1` | `0.225` |
+| `abaterate2` | `0.225` |
+| `bstcthresh` | `0` |
+| `bstcabate` | `0` |
+
+
+### `ppl`
+
+| Parameter | Value |
+| --- | --- |
+| `enabled` | `False` |
+| `weekly_rate` | `712.17` |
+| `max_weeks` | `26` |
+
+
+### `child_support`
+
+| Parameter | Value |
+| --- | --- |
+| `enabled` | `False` |
+| `support_rate` | `0.18` |
+
+
+### `acc_levy`
+
+| Parameter | Value |
+| --- | --- |
+| `rate` | `0.0153` |
+| `max_income` | `139111` |
+
+
+## 2014-2015
+
+### `tax_brackets`
+
+| Parameter | Value |
+| --- | --- |
+| `rates` | `[0.105, 0.175, 0.3, 0.33]` |
+| `thresholds` | `[14000, 48000, 70000]` |
+
+
+### `ietc`
+
+| Parameter | Value |
+| --- | --- |
+| `thrin` | `24000` |
+| `ent` | `520` |
+| `thrab` | `48000` |
+| `abrate` | `0.13` |
+
+
+### `wff`
+
+| Parameter | Value |
+| --- | --- |
+| `ftc1` | `4822` |
+| `ftc2` | `3351` |
+| `iwtc1` | `3770` |
+| `iwtc2` | `0` |
+| `bstc` | `0` |
+| `mftc` | `23036` |
+| `abatethresh1` | `36350` |
+| `abatethresh2` | `36350` |
+| `abaterate1` | `0.225` |
+| `abaterate2` | `0.225` |
+| `bstcthresh` | `0` |
+| `bstcabate` | `0` |
+
+
+### `ppl`
+
+| Parameter | Value |
+| --- | --- |
+| `enabled` | `False` |
+| `weekly_rate` | `712.17` |
+| `max_weeks` | `26` |
+
+
+### `child_support`
+
+| Parameter | Value |
+| --- | --- |
+| `enabled` | `False` |
+| `support_rate` | `0.18` |
+
+
+### `acc_levy`
+
+| Parameter | Value |
+| --- | --- |
+| `rate` | `0.0153` |
+| `max_income` | `139111` |
+
+
+## 2015-2016
+
+### `tax_brackets`
+
+| Parameter | Value |
+| --- | --- |
+| `rates` | `[0.105, 0.175, 0.3, 0.33]` |
+| `thresholds` | `[14000, 48000, 70000]` |
+
+
+### `ietc`
+
+| Parameter | Value |
+| --- | --- |
+| `thrin` | `24000` |
+| `ent` | `520` |
+| `thrab` | `48000` |
+| `abrate` | `0.13` |
+
+
+### `wff`
+
+| Parameter | Value |
+| --- | --- |
+| `ftc1` | `4822` |
+| `ftc2` | `3351` |
+| `iwtc1` | `3770` |
+| `iwtc2` | `0` |
+| `bstc` | `0` |
+| `mftc` | `23036` |
+| `abatethresh1` | `36350` |
+| `abatethresh2` | `36350` |
+| `abaterate1` | `0.225` |
+| `abaterate2` | `0.225` |
+| `bstcthresh` | `0` |
+| `bstcabate` | `0` |
+
+
+### `ppl`
+
+| Parameter | Value |
+| --- | --- |
+| `enabled` | `False` |
+| `weekly_rate` | `712.17` |
+| `max_weeks` | `26` |
+
+
+### `child_support`
+
+| Parameter | Value |
+| --- | --- |
+| `enabled` | `False` |
+| `support_rate` | `0.18` |
+
+
+### `acc_levy`
+
+| Parameter | Value |
+| --- | --- |
+| `rate` | `0.0153` |
+| `max_income` | `139111` |
+
+
+## 2016-2017
+
+### `tax_brackets`
+
+| Parameter | Value |
+| --- | --- |
+| `rates` | `[0.105, 0.175, 0.3, 0.33]` |
+| `thresholds` | `[14000, 48000, 70000]` |
+
+
+### `ietc`
+
+| Parameter | Value |
+| --- | --- |
+| `thrin` | `24000` |
+| `ent` | `520` |
+| `thrab` | `48000` |
+| `abrate` | `0.13` |
+
+
+### `wff`
+
+| Parameter | Value |
+| --- | --- |
+| `ftc1` | `4822` |
+| `ftc2` | `3351` |
+| `iwtc1` | `3770` |
+| `iwtc2` | `0` |
+| `bstc` | `0` |
+| `mftc` | `23036` |
+| `abatethresh1` | `36350` |
+| `abatethresh2` | `36350` |
+| `abaterate1` | `0.225` |
+| `abaterate2` | `0.225` |
+| `bstcthresh` | `0` |
+| `bstcabate` | `0` |
+
+
+### `ppl`
+
+| Parameter | Value |
+| --- | --- |
+| `enabled` | `False` |
+| `weekly_rate` | `712.17` |
+| `max_weeks` | `26` |
+
+
+### `child_support`
+
+| Parameter | Value |
+| --- | --- |
+| `enabled` | `False` |
+| `support_rate` | `0.18` |
+
+
+### `acc_levy`
+
+| Parameter | Value |
+| --- | --- |
+| `rate` | `0.0153` |
+| `max_income` | `139111` |
+
+
+### `jss`
+
+| Parameter | Value |
+| --- | --- |
+| `single_rate` | `0` |
+| `couple_rate` | `0` |
+| `child_rate` | `0` |
+| `income_abatement_threshold` | `0` |
+| `abatement_rate` | `0` |
+
+
+### `sps`
+
+| Parameter | Value |
+| --- | --- |
+| `base_rate` | `0` |
+| `income_abatement_threshold` | `0` |
+| `abatement_rate` | `0` |
+
+
+### `slp`
+
+| Parameter | Value |
+| --- | --- |
+| `single_rate` | `0` |
+| `couple_rate` | `0` |
+| `income_abatement_threshold` | `0` |
+| `abatement_rate` | `0` |
+
+
+### `accommodation_supplement`
+
+| Parameter | Value |
+| --- | --- |
+| `income_thresholds` | `{}` |
+| `abatement_rate` | `0` |
+| `max_entitlement_rates` | `{}` |
+| `housing_cost_contribution_rate` | `0` |
+| `housing_cost_threshold` | `0` |
+
+
+## 2017-2018
+
+### `tax_brackets`
+
+| Parameter | Value |
+| --- | --- |
+| `rates` | `[0.105, 0.175, 0.3, 0.33]` |
+| `thresholds` | `[14000, 48000, 70000]` |
+
+
+### `ietc`
+
+| Parameter | Value |
+| --- | --- |
+| `thrin` | `24000` |
+| `ent` | `520` |
+| `thrab` | `48000` |
+| `abrate` | `0.13` |
+
+
+### `wff`
+
+| Parameter | Value |
+| --- | --- |
+| `ftc1` | `4822` |
+| `ftc2` | `3351` |
+| `iwtc1` | `3770` |
+| `iwtc2` | `0` |
+| `bstc` | `0` |
+| `mftc` | `23816` |
+| `abatethresh1` | `36350` |
+| `abatethresh2` | `36350` |
+| `abaterate1` | `0.225` |
+| `abaterate2` | `0.225` |
+| `bstcthresh` | `0` |
+| `bstcabate` | `0` |
+
+
+### `ppl`
+
+| Parameter | Value |
+| --- | --- |
+| `enabled` | `False` |
+| `weekly_rate` | `712.17` |
+| `max_weeks` | `26` |
+
+
+### `child_support`
+
+| Parameter | Value |
+| --- | --- |
+| `enabled` | `False` |
+| `support_rate` | `0.18` |
+
+
+### `acc_levy`
+
+| Parameter | Value |
+| --- | --- |
+| `rate` | `0.0153` |
+| `max_income` | `139111` |
+
+
+## 2018-2019
+
+### `tax_brackets`
+
+| Parameter | Value |
+| --- | --- |
+| `rates` | `[0.105, 0.175, 0.3, 0.33]` |
+| `thresholds` | `[14000, 48000, 70000]` |
+
+
+### `ietc`
+
+| Parameter | Value |
+| --- | --- |
+| `thrin` | `24000` |
+| `ent` | `520` |
+| `thrab` | `48000` |
+| `abrate` | `0.13` |
+
+
+### `wff`
+
+| Parameter | Value |
+| --- | --- |
+| `ftc1` | `5878` |
+| `ftc2` | `4745` |
+| `iwtc1` | `3770` |
+| `iwtc2` | `0` |
+| `bstc` | `3120` |
+| `mftc` | `26156` |
+| `abatethresh1` | `41116` |
+| `abatethresh2` | `41116` |
+| `abaterate1` | `0.2438` |
+| `abaterate2` | `0.2438` |
+| `bstcthresh` | `0` |
+| `bstcabate` | `0` |
+
+
+### `ppl`
+
+| Parameter | Value |
+| --- | --- |
+| `enabled` | `False` |
+| `weekly_rate` | `712.17` |
+| `max_weeks` | `26` |
+
+
+### `child_support`
+
+| Parameter | Value |
+| --- | --- |
+| `enabled` | `False` |
+| `support_rate` | `0.18` |
+
+
+### `acc_levy`
+
+| Parameter | Value |
+| --- | --- |
+| `rate` | `0.0153` |
+| `max_income` | `139111` |
+
+
+## 2019-2020
+
+### `tax_brackets`
+
+| Parameter | Value |
+| --- | --- |
+| `rates` | `[0.105, 0.175, 0.3, 0.33]` |
+| `thresholds` | `[14000, 48000, 70000]` |
+
+
+### `ietc`
+
+| Parameter | Value |
+| --- | --- |
+| `thrin` | `24000` |
+| `ent` | `520` |
+| `thrab` | `48000` |
+| `abrate` | `0.13` |
+
+
+### `wff`
+
+| Parameter | Value |
+| --- | --- |
+| `ftc1` | `5878` |
+| `ftc2` | `4745` |
+| `iwtc1` | `3770` |
+| `iwtc2` | `0` |
+| `bstc` | `3120` |
+| `mftc` | `26572` |
+| `abatethresh1` | `42700` |
+| `abatethresh2` | `42700` |
+| `abaterate1` | `0.25` |
+| `abaterate2` | `0.25` |
+| `bstcthresh` | `0` |
+| `bstcabate` | `0` |
+
+
+### `ppl`
+
+| Parameter | Value |
+| --- | --- |
+| `enabled` | `False` |
+| `weekly_rate` | `712.17` |
+| `max_weeks` | `26` |
+
+
+### `child_support`
+
+| Parameter | Value |
+| --- | --- |
+| `enabled` | `False` |
+| `support_rate` | `0.18` |
+
+
+### `acc_levy`
+
+| Parameter | Value |
+| --- | --- |
+| `rate` | `0.0153` |
+| `max_income` | `139111` |
+
+
+## 2020-2021
+
+### `tax_brackets`
+
+| Parameter | Value |
+| --- | --- |
+| `rates` | `[0.105, 0.175, 0.3, 0.33]` |
+| `thresholds` | `[14000, 48000, 70000]` |
+
+
+### `ietc`
+
+| Parameter | Value |
+| --- | --- |
+| `thrin` | `24000` |
+| `ent` | `520` |
+| `thrab` | `48000` |
+| `abrate` | `0.13` |
+
+
+### `wff`
+
+| Parameter | Value |
+| --- | --- |
+| `ftc1` | `5878` |
+| `ftc2` | `4745` |
+| `iwtc1` | `3770` |
+| `iwtc2` | `0` |
+| `bstc` | `3120` |
+| `mftc` | `26572` |
+| `abatethresh1` | `42700` |
+| `abatethresh2` | `42700` |
+| `abaterate1` | `0.25` |
+| `abaterate2` | `0.25` |
+| `bstcthresh` | `0` |
+| `bstcabate` | `0` |
+
+
+### `ppl`
+
+| Parameter | Value |
+| --- | --- |
+| `enabled` | `False` |
+| `weekly_rate` | `712.17` |
+| `max_weeks` | `26` |
+
+
+### `child_support`
+
+| Parameter | Value |
+| --- | --- |
+| `enabled` | `False` |
+| `support_rate` | `0.18` |
+
+
+### `acc_levy`
+
+| Parameter | Value |
+| --- | --- |
+| `rate` | `0.0153` |
+| `max_income` | `139111` |
+
+
+## 2021-2022
+
+### `tax_brackets`
+
+| Parameter | Value |
+| --- | --- |
+| `rates` | `[0.105, 0.175, 0.3, 0.33, 0.39]` |
+| `thresholds` | `[14000, 48000, 70000, 180000]` |
+
+
+### `ietc`
+
+| Parameter | Value |
+| --- | --- |
+| `thrin` | `24000` |
+| `ent` | `520` |
+| `thrab` | `48000` |
+| `abrate` | `0.13` |
+
+
+### `wff`
+
+| Parameter | Value |
+| --- | --- |
+| `ftc1` | `6642` |
+| `ftc2` | `5412` |
+| `iwtc1` | `3770` |
+| `iwtc2` | `0` |
+| `bstc` | `3120` |
+| `mftc` | `26572` |
+| `abatethresh1` | `42700` |
+| `abatethresh2` | `42700` |
+| `abaterate1` | `0.27` |
+| `abaterate2` | `0.27` |
+| `bstcthresh` | `0` |
+| `bstcabate` | `0` |
+
+
+### `ppl`
+
+| Parameter | Value |
+| --- | --- |
+| `enabled` | `False` |
+| `weekly_rate` | `712.17` |
+| `max_weeks` | `26` |
+
+
+### `child_support`
+
+| Parameter | Value |
+| --- | --- |
+| `enabled` | `False` |
+| `support_rate` | `0.18` |
+
+
+### `acc_levy`
+
+| Parameter | Value |
+| --- | --- |
+| `rate` | `0.0153` |
+| `max_income` | `139111` |
+
+
+## 2022-2023
+
+### `tax_brackets`
+
+| Parameter | Value |
+| --- | --- |
+| `rates` | `[0.105, 0.175, 0.3, 0.33, 0.39]` |
+| `thresholds` | `[14000, 48000, 70000, 180000]` |
+
+
+### `ietc`
+
+| Parameter | Value |
+| --- | --- |
+| `thrin` | `24000` |
+| `ent` | `520` |
+| `thrab` | `48000` |
+| `abrate` | `0.13` |
+
+
+### `wff`
+
+| Parameter | Value |
+| --- | --- |
+| `ftc1` | `6642` |
+| `ftc2` | `5412` |
+| `iwtc1` | `3770` |
+| `iwtc2` | `780` |
+| `bstc` | `3388` |
+| `mftc` | `38627` |
+| `abatethresh1` | `42700` |
+| `abatethresh2` | `80000` |
+| `abaterate1` | `0.27` |
+| `abaterate2` | `0.27` |
+| `bstcthresh` | `79000` |
+| `bstcabate` | `0.21` |
+
+
+### `jss`
+
+| Parameter | Value |
+| --- | --- |
+| `single_rate` | `336.89` |
+| `couple_rate` | `280.74` |
+| `child_rate` | `0.0` |
+| `income_abatement_threshold` | `115.0` |
+| `abatement_rate` | `0.7` |
+
+
+### `sps`
+
+| Parameter | Value |
+| --- | --- |
+| `base_rate` | `476.69` |
+| `income_abatement_threshold` | `115.0` |
+| `abatement_rate` | `0.7` |
+
+
+### `slp`
+
+| Parameter | Value |
+| --- | --- |
+| `single_rate` | `399.09` |
+| `couple_rate` | `280.74` |
+| `income_abatement_threshold` | `115.0` |
+| `abatement_rate` | `0.7` |
+
+
+### `accommodation_supplement`
+
+| Parameter | Value |
+| --- | --- |
+| `income_thresholds` | `{'single_no_children': 250.0, 'with_children': 400.0}` |
+| `abatement_rate` | `0.25` |
+| `max_entitlement_rates` | `{'Auckland': {'single_no_children': 140.0, 'with_children': 200.0}, 'Wellington': {'single_no_children': 120.0, 'with_children': 180.0}, 'Christchurch': {'single_no_children': 100.0, 'with_children': 150.0}}` |
+| `housing_cost_contribution_rate` | `0.7` |
+| `housing_cost_threshold` | `25.0` |
+
+
+### `ppl`
+
+| Parameter | Value |
+| --- | --- |
+| `enabled` | `False` |
+| `weekly_rate` | `712.17` |
+| `max_weeks` | `26` |
+
+
+### `child_support`
+
+| Parameter | Value |
+| --- | --- |
+| `enabled` | `False` |
+| `support_rate` | `0.18` |
+
+
+### `kiwisaver`
+
+| Parameter | Value |
+| --- | --- |
+| `contribution_rate` | `0.03` |
+
+
+### `student_loan`
+
+| Parameter | Value |
+| --- | --- |
+| `repayment_threshold` | `20000` |
+| `repayment_rate` | `0.12` |
+
+
+### `acc_levy`
+
+| Parameter | Value |
+| --- | --- |
+| `rate` | `0.0153` |
+| `max_income` | `139111` |
+
+
+## 2023-2024
+
+### `tax_brackets`
+
+| Parameter | Value |
+| --- | --- |
+| `rates` | `[0.105, 0.175, 0.3, 0.33, 0.39]` |
+| `thresholds` | `[14000, 48000, 70000, 180000]` |
+
+
+### `ietc`
+
+| Parameter | Value |
+| --- | --- |
+| `thrin` | `24000` |
+| `ent` | `520` |
+| `thrab` | `48000` |
+| `abrate` | `0.13` |
+
+
+### `wff`
+
+| Parameter | Value |
+| --- | --- |
+| `ftc1` | `6642` |
+| `ftc2` | `5412` |
+| `iwtc1` | `3770` |
+| `iwtc2` | `780` |
+| `bstc` | `3388` |
+| `mftc` | `38627` |
+| `abatethresh1` | `42700` |
+| `abatethresh2` | `80000` |
+| `abaterate1` | `0.27` |
+| `abaterate2` | `0.27` |
+| `bstcthresh` | `79000` |
+| `bstcabate` | `0.21` |
+
+
+### `jss`
+
+| Parameter | Value |
+| --- | --- |
+| `single_rate` | `336.89` |
+| `couple_rate` | `280.74` |
+| `child_rate` | `0.0` |
+| `income_abatement_threshold` | `115.0` |
+| `abatement_rate` | `0.7` |
+
+
+### `sps`
+
+| Parameter | Value |
+| --- | --- |
+| `base_rate` | `476.69` |
+| `income_abatement_threshold` | `115.0` |
+| `abatement_rate` | `0.7` |
+
+
+### `slp`
+
+| Parameter | Value |
+| --- | --- |
+| `single_rate` | `399.09` |
+| `couple_rate` | `280.74` |
+| `income_abatement_threshold` | `115.0` |
+| `abatement_rate` | `0.7` |
+
+
+### `accommodation_supplement`
+
+| Parameter | Value |
+| --- | --- |
+| `income_thresholds` | `{'single_no_children': 250.0, 'with_children': 400.0}` |
+| `abatement_rate` | `0.25` |
+| `max_entitlement_rates` | `{'Auckland': {'single_no_children': 140.0, 'with_children': 200.0}, 'Wellington': {'single_no_children': 120.0, 'with_children': 180.0}, 'Christchurch': {'single_no_children': 100.0, 'with_children': 150.0}}` |
+| `housing_cost_contribution_rate` | `0.7` |
+| `housing_cost_threshold` | `25.0` |
+
+
+### `ppl`
+
+| Parameter | Value |
+| --- | --- |
+| `enabled` | `False` |
+| `weekly_rate` | `712.17` |
+| `max_weeks` | `26` |
+
+
+### `child_support`
+
+| Parameter | Value |
+| --- | --- |
+| `enabled` | `False` |
+| `support_rate` | `0.18` |
+
+
+### `acc_levy`
+
+| Parameter | Value |
+| --- | --- |
+| `rate` | `0.0153` |
+| `max_income` | `139111` |
+
+
+### `wep`
+
+| Parameter | Value |
+| --- | --- |
+| `single_rate` | `20.46` |
+| `couple_rate` | `31.82` |
+| `child_rate` | `0` |
+
+
+### `bstc`
+
+| Parameter | Value |
+| --- | --- |
+| `amount` | `3640` |
+| `threshold` | `79000` |
+| `rate` | `0.21` |
+| `max_age` | `3` |
+
+
+### `ftc`
+
+| Parameter | Value |
+| --- | --- |
+| `base_rate` | `6645` |
+| `child_rate` | `5415` |
+| `income_threshold` | `42700` |
+| `abatement_rate` | `0.27` |
+
+
+### `iwtc`
+
+| Parameter | Value |
+| --- | --- |
+| `base_rate` | `3770` |
+| `child_rate` | `780` |
+| `income_threshold` | `42700` |
+| `abatement_rate` | `0.27` |
+| `min_hours_worked` | `20` |
+
+
+### `mftc`
+
+| Parameter | Value |
+| --- | --- |
+| `guaranteed_income` | `34320` |
+
+
+### `rwt`
+
+| Parameter | Value |
+| --- | --- |
+| `rwt_rate_10_5` | `0.105` |
+| `rwt_rate_17_5` | `0.175` |
+| `rwt_rate_30` | `0.3` |
+| `rwt_rate_33` | `0.33` |
+| `rwt_rate_39` | `0.39` |
+
+
+## 2024-2025
+
+### `tax_brackets`
+
+| Parameter | Value |
+| --- | --- |
+| `rates` | `[0.105, 0.1282, 0.175, 0.2164, 0.3, 0.3099, 0.33, 0.39]` |
+| `thresholds` | `[14000, 15600, 48000, 53500, 70000, 78100, 180000]` |
+
+
+### `ietc`
+
+| Parameter | Value |
+| --- | --- |
+| `thrin` | `24000` |
+| `ent` | `520` |
+| `thrab` | `66000` |
+| `abrate` | `0.13` |
+
+
+### `wff`
+
+| Parameter | Value |
+| --- | --- |
+| `ftc1` | `6642` |
+| `ftc2` | `5412` |
+| `iwtc1` | `5070` |
+| `iwtc2` | `780` |
+| `bstc` | `3388` |
+| `mftc` | `38627` |
+| `abatethresh1` | `42700` |
+| `abatethresh2` | `80000` |
+| `abaterate1` | `0.27` |
+| `abaterate2` | `0.27` |
+| `bstcthresh` | `79000` |
+| `bstcabate` | `0.21` |
+
+
+### `jss`
+
+| Parameter | Value |
+| --- | --- |
+| `single_rate` | `336.89` |
+| `couple_rate` | `280.74` |
+| `child_rate` | `0.0` |
+| `income_abatement_threshold` | `115.0` |
+| `abatement_rate` | `0.7` |
+
+
+### `sps`
+
+| Parameter | Value |
+| --- | --- |
+| `base_rate` | `476.69` |
+| `income_abatement_threshold` | `115.0` |
+| `abatement_rate` | `0.7` |
+
+
+### `slp`
+
+| Parameter | Value |
+| --- | --- |
+| `single_rate` | `399.09` |
+| `couple_rate` | `280.74` |
+| `income_abatement_threshold` | `115.0` |
+| `abatement_rate` | `0.7` |
+
+
+### `accommodation_supplement`
+
+| Parameter | Value |
+| --- | --- |
+| `income_thresholds` | `{'single_no_children': 250.0, 'with_children': 400.0}` |
+| `abatement_rate` | `0.25` |
+| `max_entitlement_rates` | `{'Auckland': {'single_no_children': 140.0, 'with_children': 200.0}, 'Wellington': {'single_no_children': 120.0, 'with_children': 180.0}, 'Christchurch': {'single_no_children': 100.0, 'with_children': 150.0}}` |
+| `housing_cost_contribution_rate` | `0.7` |
+| `housing_cost_threshold` | `25.0` |
+
+
+### `family_boost`
+
+| Parameter | Value |
+| --- | --- |
+| `max_credit` | `3900` |
+| `income_threshold` | `140000` |
+| `abatement_rate` | `0.25` |
+| `max_income` | `180000` |
+
+
+### `ppl`
+
+| Parameter | Value |
+| --- | --- |
+| `enabled` | `False` |
+| `weekly_rate` | `712.17` |
+| `max_weeks` | `26` |
+
+
+### `child_support`
+
+| Parameter | Value |
+| --- | --- |
+| `enabled` | `False` |
+| `support_rate` | `0.18` |
+| `living_allowance` | `17518.28` |
+
+
+### `kiwisaver`
+
+| Parameter | Value |
+| --- | --- |
+| `contribution_rate` | `0.03` |
+
+
+### `student_loan`
+
+| Parameter | Value |
+| --- | --- |
+| `repayment_threshold` | `20000` |
+| `repayment_rate` | `0.12` |
+
+
+### `acc_levy`
+
+| Parameter | Value |
+| --- | --- |
+| `rate` | `0.0153` |
+| `max_income` | `139111` |
+
+
+### `pie`
+
+| Parameter | Value |
+| --- | --- |
+| `rates` | `[0.105, 0.175, 0.28]` |
+| `taxable_income_thresholds` | `[15600, 53500]` |
+| `taxable_plus_pie_income_thresholds` | `[53500, 78100]` |
+
+
+### `disability_allowance`
+
+| Parameter | Value |
+| --- | --- |
+| `max_payment` | `80.35` |
+| `income_thresholds` | `{'single_16_17': 675.6, 'single_18_plus': 843.78, 'couple': 1256.07, 'sole_parent_1_child': 942.23, 'sole_parent_2_plus_children': 992.74}` |
+
+
+### `donation_credit`
+
+| Parameter | Value |
+| --- | --- |
+| `credit_rate` | `0.3333333333333333` |
+| `min_donation` | `5.0` |

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -21,6 +21,7 @@ nav:
     - 'Development Log': 'development_log.md'
     - 'Security': 'SECURITY.md'
   - 'Model Documentation':
+    - 'Parameter Coverage': 'parameter_coverage.md'
     - 'Data Dictionary': 'data_dictionary.md'
     - 'Feature Matrix': 'feature_matrix.md'
     - 'Policy Changes': 'policy_changes.md'

--- a/scripts/generate_parameter_docs.py
+++ b/scripts/generate_parameter_docs.py
@@ -1,0 +1,109 @@
+import json
+import os
+from pathlib import Path
+import re
+
+def get_parameter_files(src_dir: Path) -> list[Path]:
+    """Finds all parameter files in the src directory."""
+    return sorted(src_dir.glob("parameters_*.json"))
+
+def get_all_rules(param_files: list[Path]) -> list[str]:
+    """Gets a unique, sorted list of all rules from all parameter files."""
+    all_rules = set()
+    for file in param_files:
+        with open(file, "r") as f:
+            data = json.load(f)
+            all_rules.update(data.keys())
+    # These are not rules, so remove them.
+    if "year" in all_rules:
+        all_rules.remove("year")
+    if "description" in all_rules:
+        all_rules.remove("description")
+    return sorted(list(all_rules))
+
+def generate_coverage_matrix(param_data: dict, all_rules: list[str]) -> str:
+    """Generates a Markdown table for rule coverage."""
+    header = "| Year | " + " | ".join(f"`{rule}`" for rule in all_rules) + " |"
+    separator = "| --- |" + " :---: |" * len(all_rules)
+
+    rows = []
+    for year, data in param_data.items():
+        row = f"| {year} |"
+        for rule in all_rules:
+            row += " ✅ |" if rule in data else " ❌ |"
+        rows.append(row)
+
+    return "\n".join([header, separator] + rows)
+
+def generate_detailed_tables(param_data: dict) -> str:
+    """Generates detailed Markdown tables for each year's parameters."""
+    detailed_docs = []
+    for year, data in param_data.items():
+        detailed_docs.append(f"## {year}\n")
+        for rule, params in data.items():
+            if rule in ["year", "description"]:
+                continue
+            detailed_docs.append(f"### `{rule}`\n")
+            if isinstance(params, dict):
+                header = "| Parameter | Value |\n| --- | --- |"
+                rows = [f"| `{key}` | `{value}` |" for key, value in params.items()]
+                detailed_docs.append(header + "\n" + "\n".join(rows))
+            else:
+                detailed_docs.append(f"`{params}`")
+            detailed_docs.append("\n")
+    return "\n".join(detailed_docs)
+
+
+def generate_docs():
+    """
+    Generates documentation for the parameter files.
+    """
+    print("Generating parameter documentation...")
+
+    # Correctly locate the root directory of the project
+    root_dir = Path(__file__).parent.parent
+    src_dir = root_dir / "src"
+    docs_dir = root_dir / "docs"
+    output_file = docs_dir / "parameter_coverage.md"
+
+    param_files = get_parameter_files(src_dir)
+
+    param_data = {}
+    year_pattern = re.compile(r"parameters_(\d{4}-\d{4})\.json")
+
+    for file in param_files:
+        print(f"Processing file: {file.name}") # Added for debugging
+        match = year_pattern.search(file.name)
+        if match:
+            year = match.group(1)
+            with open(file, "r") as f:
+                param_data[year] = json.load(f)
+
+    # Sort data by year
+    param_data = dict(sorted(param_data.items()))
+
+    all_rules = get_all_rules(param_files)
+
+    # Generate the content
+    title = "# Parameter Coverage\n\n"
+    intro = "This page automatically documents the coverage of policy rules across different years, based on the available parameter files.\n\n"
+
+    matrix_title = "## Rule Coverage Matrix\n\n"
+    matrix = generate_coverage_matrix(param_data, all_rules)
+
+    details_title = "\n\n## Detailed Parameters by Year\n"
+    details = generate_detailed_tables(param_data)
+
+    # Write to the output file
+    with open(output_file, "w") as f:
+        f.write(title)
+        f.write(intro)
+        f.write(matrix_title)
+        f.write(matrix)
+        f.write(details_title)
+        f.write(details)
+
+    print(f"Documentation generated successfully at {output_file}")
+
+if __name__ == "__main__":
+    generate_docs()

--- a/src/benefit_rules.py
+++ b/src/benefit_rules.py
@@ -115,49 +115,6 @@ class DisabilityAllowanceRule(Rule):
         )
 
 
-@register_rule
-@dataclass
-class DisabilityAllowanceRule(Rule):
-    """A rule to calculate the Disability Allowance.
-
-    The Disability Allowance is a weekly payment for people who have regular,
-    ongoing costs because of a disability.
-
-    This rule calculates the Disability Allowance entitlement based on income,
-    disability-related costs, and family situation.
-
-    The calculation is performed by the `calculate_disability_allowance`
-    function.
-    """
-
-    disability_allowance_params: DisabilityAllowanceParams
-    name: str = "disability_allowance"
-    enabled: bool = True
-
-    def __call__(self, data: dict[str, Any]) -> None:
-        """Calculate Disability Allowance entitlement and add it to the DataFrame.
-
-        This method applies the `calculate_disability_allowance` function to
-        each row of the DataFrame in the `data` dictionary and stores the
-        result in a new `disability_allowance_entitlement` column.
-
-        Args:
-            data: The data dictionary, expected to contain a 'df' key with
-                a pandas DataFrame. The DataFrame must contain
-                'total_individual_income_weekly', 'disability_costs', and
-                'family_situation' columns.
-        """
-        data["df"]["disability_allowance_entitlement"] = data["df"].apply(
-            lambda row: calculate_disability_allowance(
-                weekly_income=row["total_individual_income_weekly"],
-                disability_costs=row["disability_costs"],
-                family_situation=row["family_situation"],
-                params=self.disability_allowance_params,
-            ),
-            axis=1,
-        )
-
-
 @dataclass
 class MFTCRule(Rule):
     """A rule to calculate the Minimum Family Tax Credit (MFTC).

--- a/src/parameters_1964-1965.json
+++ b/src/parameters_1964-1965.json
@@ -45,7 +45,7 @@
         "ftc1": 0,
         "ftc2": 0,
         "iwtc1": 0,
-        "iwtc2": 0,,
+        "iwtc2": 0,
         "bstc": 0,
         "mftc": 0,
         "abatethresh1": 0,

--- a/src/tax_calculator.py
+++ b/src/tax_calculator.py
@@ -4,13 +4,8 @@ import math
 
 from pydantic import BaseModel
 
-<<<<<<< HEAD
 from .investment_tax import calculate_pie_tax
 from .microsim import load_parameters, simrwt, taxit
-=======
-from .microsim import load_parameters, simrwt, taxit
-from .investment_tax import calculate_pie_tax
->>>>>>> 534254760198f932d3d677da94076bf62c87c7fd
 from .parameters import (
     DonationCreditParams,
     FamilyBoostParams,

--- a/tests/test_tax_calculator.py
+++ b/tests/test_tax_calculator.py
@@ -113,8 +113,4 @@ def test_tax_calculator_pie_tax() -> None:
 
     # Test with a year that does not have PIE params
     calc_without_pie = TaxCalculator.from_year("2023-2024")
-<<<<<<< HEAD
     assert calc_without_pie.pie_tax(pie_income, taxable_income) == 0.0
-=======
-    assert calc_without_pie.pie_tax(pie_income, taxable_income) == 0.0
->>>>>>> 534254760198f932d3d677da94076bf62c87c7fd


### PR DESCRIPTION
I've introduced a new script, `scripts/generate_parameter_docs.py`, that automates the creation of documentation for the model's parameter files.

The script performs the following actions:
- Scans the `src/` directory for all `parameters_*.json` files.
- Generates a "Rule Coverage Matrix" that provides a high-level overview of which policy rules are defined for each available year.
- Generates detailed tables for each year, listing every parameter and its corresponding value.

This generated documentation is saved to `docs/parameter_coverage.md`.

Additionally, I updated `mkdocs.yml` to include the new page in the site navigation, making it accessible to you. This addresses your need for clear, up-to-date documentation on parameter and feature availability across different years.