### PR TITLE
build: Configure bandit to exclude .tox directory

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,6 +56,10 @@ disable_error_code = ["var-annotated"]
 
 [tool.coverage.run]
 source = ["src"]
+omit = ["*/shibokensupport/*", "signature_bootstrap.py"]
 
 [tool.setuptools.package-data]
 nztaxmicrosim = ["docs/*"]
+
+[tool.bandit]
+exclude = [".tox"]


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Refined code coverage settings to omit non-application/support modules, yielding more accurate coverage metrics and cleaner reports.

* **Chores**
  * Configured security scanning to exclude temporary/build/test environment directories, reducing false positives and noise in analysis outputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->